### PR TITLE
refactor environment variables handling and remove unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ make test
 * Download and install the [Aptos CLI](https://aptos.dev/tools/aptos-cli/use-cli/running-a-local-network).
 * Set the environment variable `APTOS_CLI_PATH` to the full path of the CLI.
 * Retrieve the [Aptos Core Github Repo](https://github.com/aptos-labs/aptos-core) (git clone https://github.com/aptos-labs/aptos-core)
-* Set the environment variable `APTOS_CORE_REPO` to the full path of the Repository.
+* Set the environment variable `APTOS_CORE_PATH` to the full path of the Repository.
 * `make integration_test`
 
 You can do this a bit more manually by:
@@ -41,7 +41,7 @@ aptos node run-local-testnet --force-restart --assume-yes --with-indexer-api
 Next, tell the end-to-end tests to talk to this locally running testnet:
 
 ```bash
-export APTOS_CORE_REPO="/path/to/repo"
+export APTOS_CORE_PATH="/path/to/repo"
 export APTOS_FAUCET_URL="http://127.0.0.1:8081"
 export APTOS_INDEXER_URL="http://127.0.0.1:8090/v1/graphql"
 export APTOS_NODE_URL="http://127.0.0.1:8080/v1"

--- a/examples/common.py
+++ b/examples/common.py
@@ -13,9 +13,6 @@ FAUCET_URL = os.getenv(
     "APTOS_FAUCET_URL",
     "https://faucet.devnet.aptoslabs.com",
 )
-INDEXER_URL = os.getenv(
-    "APTOS_INDEXER_URL",
-    "https://api.devnet.aptoslabs.com/v1/graphql",
-)
+INDEXER_URL = os.getenv("APTOS_INDEXER_URL")
 NODE_URL = os.getenv("APTOS_NODE_URL", "https://api.devnet.aptoslabs.com/v1")
 # <:!:section_1

--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -13,24 +13,27 @@ from typing import Optional
 from aptos_sdk.account_address import AccountAddress
 from aptos_sdk.aptos_cli_wrapper import AptosCLIWrapper, AptosInstance
 
-from .common import APTOS_CORE_PATH
-
 
 class Test(unittest.IsolatedAsyncioTestCase):
     _node: Optional[AptosInstance] = None
+    _aptos_core_path: str
 
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
+        cls._aptos_core_path = os.getenv("APTOS_CORE_PATH")
+        if not cls._aptos_core_path:
+            raise Exception("Environment variable `APTOS_CORE_PATH` is not set")
+
         if os.getenv("APTOS_TEST_USE_EXISTING_NETWORK"):
             return
 
-        self._node = AptosCLIWrapper.start_node()
-        operational = asyncio.run(self._node.wait_until_operational())
+        cls._node = AptosCLIWrapper.start_node()
+        operational = asyncio.run(cls._node.wait_until_operational())
         if not operational:
-            raise Exception("".join(self._node.errors()))
+            raise Exception("".join(cls._node.errors()))
 
         os.environ["APTOS_FAUCET_URL"] = "http://127.0.0.1:8081"
-        os.environ["APTOS_INDEXER_CLIENT"] = "none"
+        os.environ["APTOS_INDEXER_URL"] = "none"
         os.environ["APTOS_NODE_URL"] = "http://127.0.0.1:8080/v1"
 
     async def test_aptos_token(self):
@@ -47,7 +50,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
         from . import hello_blockchain
 
         hello_blockchain_dir = os.path.join(
-            APTOS_CORE_PATH, "aptos-move", "move-examples", "hello_blockchain"
+            self._aptos_core_path, "aptos-move", "move-examples", "hello_blockchain"
         )
         AptosCLIWrapper.test_package(
             hello_blockchain_dir, {"hello_blockchain": AccountAddress.from_str("0xa")}
@@ -62,7 +65,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
         from . import large_package_publisher
 
         large_packages_dir = os.path.join(
-            APTOS_CORE_PATH, "aptos-move", "move-examples", "large_packages"
+            self._aptos_core_path, "aptos-move", "move-examples", "large_packages"
         )
         module_addr = await large_package_publisher.publish_large_packages(
             large_packages_dir
@@ -121,7 +124,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
         from . import your_coin
 
         moon_coin_path = os.path.join(
-            APTOS_CORE_PATH, "aptos-move", "move-examples", "moon_coin"
+            self._aptos_core_path, "aptos-move", "move-examples", "moon_coin"
         )
         AptosCLIWrapper.test_package(
             moon_coin_path, {"MoonCoin": AccountAddress.from_str("0xa")}
@@ -129,11 +132,11 @@ class Test(unittest.IsolatedAsyncioTestCase):
         await your_coin.main(moon_coin_path)
 
     @classmethod
-    def tearDownClass(self):
+    def tearDownClass(cls):
         if os.getenv("APTOS_TEST_USE_EXISTING_NETWORK"):
             return
 
-        self._node.stop()
+        cls._node.stop()
 
 
 if __name__ == "__main__":

--- a/examples/multikey.py
+++ b/examples/multikey.py
@@ -7,7 +7,7 @@ from aptos_sdk import asymmetric_crypto_wrapper, ed25519, secp256k1_ecdsa
 from aptos_sdk.account import Account
 from aptos_sdk.account_address import AccountAddress
 from aptos_sdk.asymmetric_crypto_wrapper import MultiSignature, Signature
-from aptos_sdk.async_client import FaucetClient, IndexerClient, RestClient
+from aptos_sdk.async_client import FaucetClient, RestClient
 from aptos_sdk.authenticator import AccountAuthenticator, MultiKeyAuthenticator
 from aptos_sdk.bcs import Serializer
 from aptos_sdk.transactions import (
@@ -17,17 +17,13 @@ from aptos_sdk.transactions import (
     TransactionPayload,
 )
 
-from .common import FAUCET_URL, INDEXER_URL, NODE_URL
+from .common import FAUCET_URL, NODE_URL
 
 
 async def main():
     # :!:>section_1
     rest_client = RestClient(NODE_URL)
     faucet_client = FaucetClient(FAUCET_URL, rest_client)  # <:!:section_1
-    if INDEXER_URL and INDEXER_URL != "none":
-        IndexerClient(INDEXER_URL)
-    else:
-        pass
 
     # :!:>section_2
     key1 = secp256k1_ecdsa.PrivateKey.random()


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->
* common.py: removed default `INDEXER_URL` value since it shouldn't be set when we're running localnet without an indexer.

* integration_test.py: decoupled from common.py since currently it is also loaded in each test case, but only imported once at import time of integration_test.py. This nullifies environment variable handling in the `setUpClass` method.

* multikey.py: removed unused code

* README.md: `APTOS_CORE_REPO` => `APTOS_CORE_PATH`

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
### Related Links
<!-- Please link to any relevant issues or pull requests! -->