### PR TITLE
Add support for publishing large packages to PackagePublisher

### DIFF
--- a/examples/integration_test.py
+++ b/examples/integration_test.py
@@ -56,9 +56,6 @@ class Test(unittest.IsolatedAsyncioTestCase):
         await hello_blockchain.main(contract_address)
 
     async def test_large_package_publisher(self):
-        # TODO -- this is currently broken, out of gas
-        return
-
         from . import large_package_publisher
 
         large_packages_dir = os.path.join(

--- a/examples/large_package_publisher.py
+++ b/examples/large_package_publisher.py
@@ -1,13 +1,5 @@
 # Copyright © Aptos Foundation
 # SPDX-License-Identifier: Apache-2.0
-"""
-This example depends on the MoonCoin.move module having already been published to the destination blockchain.
-One method to do so is to use the CLI:
-    * Acquire the Aptos CLI, see https://aptos.dev/cli-tools/aptos-cli-tool/install-aptos-cli
-    * `python -m examples.your-coin ~/aptos-core/aptos-move/move-examples/moon_coin`.
-    * Open another terminal and `aptos move compile --package-dir ~/aptos-core/aptos-move/move-examples/moon_coin --save-metadata --named-addresses MoonCoin=<Alice address from above step>`.
-    * Return to the first terminal and press enter.
-"""
 import asyncio
 import os
 import sys
@@ -17,7 +9,7 @@ from aptos_sdk.account import Account
 from aptos_sdk.account_address import AccountAddress
 from aptos_sdk.aptos_cli_wrapper import AptosCLIWrapper
 from aptos_sdk.async_client import ClientConfig, FaucetClient, RestClient
-from aptos_sdk.package_publisher import MODULE_ADDRESS, PackagePublisher
+from aptos_sdk.package_publisher import MODULE_ADDRESS, PackagePublisher, PublishMode
 
 from .common import APTOS_CORE_PATH, FAUCET_URL, NODE_URL
 
@@ -36,13 +28,14 @@ async def publish_large_packages(large_packages_dir) -> AccountAddress:
 
 async def main(
     large_package_example_dir,
-    large_packages_account: AccountAddress = MODULE_ADDRESS,
+    large_packages_module_address: AccountAddress = MODULE_ADDRESS,
 ):
     client_config = ClientConfig()
     client_config.transaction_wait_in_seconds = 120
     client_config.max_gas_amount = 1_000_000
     rest_client = RestClient(NODE_URL, client_config)
     faucet_client = FaucetClient(FAUCET_URL, rest_client)
+    publisher = PackagePublisher(rest_client)
 
     alice = Account.generate()
     req0 = faucet_client.fund_account(alice.address(), 1_000_000_000)
@@ -52,17 +45,99 @@ async def main(
     alice_balance = await rest_client.account_balance(alice.address())
     print(f"Alice: {alice.address()} {alice_balance}")
 
+    # Name of the move module for the package to be published, containing artifacts larger than the MAX_CHUNK_SIZE
+    module_name = "large_package_example"
+
+    # Example 1. Account deployment
+    print("=== Publishing large package to account ===")
+
     if AptosCLIWrapper.does_cli_exist():
         AptosCLIWrapper.compile_package(
-            large_package_example_dir, {"large_package_example": alice.address()}
+            large_package_example_dir, {module_name: alice.address()}
         )
     else:
         input("\nUpdate the module with Alice's address, compile, and press Enter.")
 
-    publisher = PackagePublisher(rest_client)
-    await publisher.publish_package_in_path(
-        alice, large_package_example_dir, large_packages_account
+    account_deploy_txn_hash = await publisher.publish_package_in_path(
+        alice, large_package_example_dir, large_packages_module_address
     )
+
+    print(f"Tx submitted: {account_deploy_txn_hash[0]}")
+    await rest_client.wait_for_transaction(account_deploy_txn_hash[0])
+    print(f"Package deployed to account {alice.address()}")
+
+    # Example 2. Object code deployment
+    # Note: Here we assume that we already know we should use the chunked publish mode, so we run a preliminary build.
+    print("=== Publishing large package to object ===")
+
+    # Calculate the number of transactions needed for the chunked publish to predict the code object address.
+    # Start by deriving the address assuming a single transaction for a preliminary build to estimate artifact size.
+    code_object_address = await publisher.derive_object_address(alice.address())
+
+    print("\nCompiling package as a preliminary build...")
+    if AptosCLIWrapper.does_cli_exist():
+        AptosCLIWrapper.compile_package(
+            large_package_example_dir, {module_name: code_object_address}
+        )
+    else:
+        print(f"Address of the object to be created: {code_object_address}")
+        input(
+            "\nUpdate the module with the derived code object address, compile, and press enter."
+        )
+
+    metadata, modules = publisher.load_package_artifacts(large_package_example_dir)
+
+    # Number of transactions required for the chunked publish.
+    required_txns = len(
+        publisher.prepare_chunked_payloads(
+            metadata,
+            modules,
+            large_packages_module_address,
+            PublishMode.OBJECT_DEPLOY,
+        )
+    )
+
+    if required_txns > 1:
+        code_object_address = await publisher.derive_object_address(
+            alice.address(), required_txns
+        )
+        print("\nCompiling the package with updated object address...")
+        if AptosCLIWrapper.does_cli_exist():
+            AptosCLIWrapper.compile_package(
+                large_package_example_dir, {module_name: code_object_address}
+            )
+        else:
+            print(f"Address of the object to be created: {code_object_address}")
+            input(
+                "\nUpdate the module with the derived code object address, compile, and press enter."
+            )
+
+    object_deploy_txn_hash = await publisher.publish_package_in_path(
+        alice,
+        large_package_example_dir,
+        large_packages_module_address,
+        PublishMode.OBJECT_DEPLOY,
+    )
+
+    print(f"The last tx submitted: {object_deploy_txn_hash[-1]}")
+    await rest_client.wait_for_transaction(object_deploy_txn_hash[-1])
+    print(f"Package deployed to object {code_object_address}")
+
+    # Example 3. Object code upgrade
+    print("=== Upgrading large package object ===")
+
+    object_upgrade_txn_hash = await publisher.publish_package_in_path(
+        alice,
+        large_package_example_dir,
+        large_packages_module_address,
+        PublishMode.OBJECT_UPGRADE,
+        code_object_address,
+    )
+
+    print(f"The last tx submitted: {object_upgrade_txn_hash[-1]}")
+    await rest_client.wait_for_transaction(object_upgrade_txn_hash[-1])
+    print(f"Package in object {code_object_address} upgraded")
+    await rest_client.close()
 
 
 if __name__ == "__main__":

--- a/examples/object_code_deployment.py
+++ b/examples/object_code_deployment.py
@@ -57,7 +57,7 @@ async def main(package_dir):
         package_dir,
         MODULE_ADDRESS,
         publish_mode=PublishMode.OBJECT_UPGRADE,
-        code_object=code_object_address,
+        code_object_address=code_object_address,
     )
     print(f"Tx submitted: {upgrade_txn_hash[0]}")
     await rest_client.wait_for_transaction(upgrade_txn_hash[0])


### PR DESCRIPTION
### Description
<!-- Please describe your change and its motivation. -->

Note: The integration test will fail on localnet due to a dependency on [this PR](https://github.com/aptos-labs/aptos-core/pull/14930), which updates the function argument type in the large_packages.move module.

Note: Since the PackagePublisher doesn't include a Move compilation feature, users may face inconvenience having to manually derive object addresses where the large package will be deployed, as shown in the `examples/large_package_publisher.py` example.

- Updated `large_packages` Move module address
- Downsized chunk size to 60KB
- Made methods in PackagePublisher reusable in examples
- Added object deployment and upgrade options for chunked publishing
- Updated `large_package_publisher` example

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->
```
make integration_test
```
### Related Links
<!-- Please link to any relevant issues or pull requests! -->