### PR TITLE
[aip80] Default ed25519 and secp256k1 private key's __str__ to AIP80

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,6 @@ cython_debug/
 .idea/
 
 # testing/fidling script:
+
+# MacOS
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the Aptos Python SDK will be captured in this file. This changelog is written by hand for now.
 
+## Unreleased
+
+- **[Breaking Change]**: `ed25519` and `secp256k1` private key's `__str__` will now return the AIP-80 compliant string
+
 ## 0.11.0
 
 - `PrivateKey.format_private_key` can now format a AIP-80 compliant private key

--- a/aptos_sdk/ed25519.py
+++ b/aptos_sdk/ed25519.py
@@ -26,7 +26,7 @@ class PrivateKey(asymmetric_crypto.PrivateKey):
         return self.key == other.key
 
     def __str__(self):
-        return self.hex()
+        return self.aip80()
 
     @staticmethod
     def from_hex(value: str | bytes, strict: bool | None = None) -> PrivateKey:
@@ -324,6 +324,10 @@ class Test(unittest.TestCase):
             private_key_with_prefix.hex(),
             private_key_bytes.hex(),
         )
+
+    def test_private_key_aip80_formatting(self):
+        private_key_with_prefix = "ed25519-priv-0x4e5e3be60f4bbd5e98d086d932f3ce779ff4b58da99bf9e5241ae1212a29e5fe"
+        self.assertEqual(str(PrivateKey.from_str(private_key_with_prefix, True)), private_key_with_prefix)
 
     def test_sign_and_verify(self):
         in_value = b"test_message"

--- a/aptos_sdk/ed25519.py
+++ b/aptos_sdk/ed25519.py
@@ -327,7 +327,10 @@ class Test(unittest.TestCase):
 
     def test_private_key_aip80_formatting(self):
         private_key_with_prefix = "ed25519-priv-0x4e5e3be60f4bbd5e98d086d932f3ce779ff4b58da99bf9e5241ae1212a29e5fe"
-        self.assertEqual(str(PrivateKey.from_str(private_key_with_prefix, True)), private_key_with_prefix)
+        self.assertEqual(
+            str(PrivateKey.from_str(private_key_with_prefix, True)),
+            private_key_with_prefix,
+        )
 
     def test_sign_and_verify(self):
         in_value = b"test_message"

--- a/aptos_sdk/secp256k1_ecdsa.py
+++ b/aptos_sdk/secp256k1_ecdsa.py
@@ -223,7 +223,10 @@ class Test(unittest.TestCase):
 
     def test_private_key_aip80_formatting(self):
         private_key_with_prefix = "secp256k1-priv-0x306fa009600e27c09d2659145ce1785249360dd5fb992da01a578fe67ed607f4"
-        self.assertEqual(str(PrivateKey.from_str(private_key_with_prefix, True)), private_key_with_prefix)
+        self.assertEqual(
+            str(PrivateKey.from_str(private_key_with_prefix, True)),
+            private_key_with_prefix,
+        )
 
     def test_vectors(self):
         private_key_hex = "secp256k1-priv-0x306fa009600e27c09d2659145ce1785249360dd5fb992da01a578fe67ed607f4"

--- a/aptos_sdk/secp256k1_ecdsa.py
+++ b/aptos_sdk/secp256k1_ecdsa.py
@@ -27,7 +27,7 @@ class PrivateKey(asymmetric_crypto.PrivateKey):
         return self.key == other.key
 
     def __str__(self):
-        return self.hex()
+        return self.aip80()
 
     @staticmethod
     def from_hex(value: str | bytes, strict: bool | None = None) -> PrivateKey:
@@ -63,7 +63,7 @@ class PrivateKey(asymmetric_crypto.PrivateKey):
 
     def aip80(self) -> str:
         return PrivateKey.format_private_key(
-            self.hex(), asymmetric_crypto.PrivateKeyVariant.Ed25519
+            self.hex(), asymmetric_crypto.PrivateKeyVariant.Secp256k1
         )
 
     def public_key(self) -> PublicKey:
@@ -220,6 +220,10 @@ class Test(unittest.TestCase):
             private_key_with_prefix.hex(),
             private_key_bytes.hex(),
         )
+
+    def test_private_key_aip80_formatting(self):
+        private_key_with_prefix = "secp256k1-priv-0x306fa009600e27c09d2659145ce1785249360dd5fb992da01a578fe67ed607f4"
+        self.assertEqual(str(PrivateKey.from_str(private_key_with_prefix, True)), private_key_with_prefix)
 
     def test_vectors(self):
         private_key_hex = "secp256k1-priv-0x306fa009600e27c09d2659145ce1785249360dd5fb992da01a578fe67ed607f4"


### PR DESCRIPTION
### Description
Default the `ed25519` and `secp256k1` private keys `__str__` override to format to AIP-80 strings

### Test Plan
- [x] Formatting tests passes

### Related Links
https://github.com/aptos-labs/aptos-python-sdk/pull/46