### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -7,6 +7,9 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/7](https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow involves checking out code and publishing to PyPI, it requires `contents: read` for accessing the repository's contents and `packages: write` for publishing the package. These permissions will be explicitly defined at the job level to limit their scope to the `release` job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
