### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -1,4 +1,6 @@
 name: "Local validation"
+permissions:
+  contents: read
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/6](https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/6)

To fix the issue, add a `permissions` block at the root level of the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the tasks performed in the workflow (e.g., linting, formatting checks, and running tests), the minimal required permission is `contents: read`. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unintended write operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
