### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/localnet-examples.yaml
+++ b/.github/workflows/localnet-examples.yaml
@@ -1,4 +1,6 @@
 name: "Localnet Examples"
+permissions:
+  contents: read
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/5](https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/5)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function. Based on the provided code, the workflow appears to only need `contents: read` permissions. This change will ensure that the `GITHUB_TOKEN` used in the workflow has restricted access, reducing the risk of unauthorized actions.

The `permissions` block can be added at the root level of the workflow file to apply to all jobs, or it can be added specifically to the `run-localnet-examples` job. In this case, adding it at the root level is sufficient and simplifies the configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
