### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/devnet-examples.yaml
+++ b/.github/workflows/devnet-examples.yaml
@@ -1,4 +1,6 @@
 name: "Devnet Examples"
+permissions:
+  contents: read
 on:
   pull_request:
     types: [labeled, opened, synchronize, reopened, auto_merge_enabled]


### PR DESCRIPTION
Potential fix for [https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/4](https://github.com/aptos-labs/aptos-python-sdk/security/code-scanning/4)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's operations, it appears that only `contents: read` is necessary, as the workflow does not perform any write operations or interact with other GitHub resources.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added specifically to the `run-devnet-examples` job. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
