### PR TITLE
Optimize BCS serialization, signing, and type tag parsing

### DIFF
--- a/aptos_sdk/bcs.py
+++ b/aptos_sdk/bcs.py
@@ -173,15 +173,15 @@ class Serializer:
         key_encoder: typing.Callable[[Serializer, typing.Any], None],
         value_encoder: typing.Callable[[Serializer, typing.Any], None],
     ):
-        encoded_values = []
+        encoded_pairs = []
         for key, value in values.items():
-            encoded_values.append((encoder(key, key_encoder), encoder(value, value_encoder)))
-        encoded_values.sort(key=lambda item: item[0])
+            encoded_pairs.append((encoder(key, key_encoder), value))
+        encoded_pairs.sort(key=lambda item: item[0])
 
-        self.uleb128(len(encoded_values))
-        for key, value in encoded_values:
-            self.fixed_bytes(key)
-            self.fixed_bytes(value)
+        self.uleb128(len(encoded_pairs))
+        for encoded_key, value in encoded_pairs:
+            self.fixed_bytes(encoded_key)
+            value_encoder(self, value)
 
     @staticmethod
     def sequence_serializer(
@@ -196,7 +196,7 @@ class Serializer:
     ):
         self.uleb128(len(values))
         for value in values:
-            self.fixed_bytes(encoder(value, value_encoder))
+            value_encoder(self, value)
 
     def str(self, value: str):
         self.to_bytes(value.encode())

--- a/aptos_sdk/transactions.py
+++ b/aptos_sdk/transactions.py
@@ -28,14 +28,15 @@ from .bcs import Deserializable, Deserializer, Serializable, Serializer
 from .errors import DeserializationError, InvalidTypeError, SerializationError
 from .type_tag import StructTag, TypeTag
 
+_RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
+_RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
+
 
 class RawTransactionInternal(Protocol):
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(self.prehash())
-        prehash.extend(ser.output())
-        return bytes(prehash)
+        return self.prehash() + ser.output()
 
     def prehash(self) -> bytes: ...
 
@@ -70,9 +71,7 @@ class RawTransactionWithData(RawTransactionInternal, Protocol):
         return self.raw_transaction
 
     def prehash(self) -> bytes:
-        hasher = hashlib.sha3_256()
-        hasher.update(b"APTOS::RawTransactionWithData")
-        return hasher.digest()
+        return _RAW_TXN_WITH_DATA_PREHASH
 
     @staticmethod
     def deserialize(deserializer: Deserializer) -> RawTransactionWithData:
@@ -145,9 +144,7 @@ class RawTransaction(Deserializable, RawTransactionInternal, Serializable):
 """
 
     def prehash(self) -> bytes:
-        hasher = hashlib.sha3_256()
-        hasher.update(b"APTOS::RawTransaction")
-        return hasher.digest()
+        return _RAW_TXN_PREHASH
 
     @staticmethod
     def deserialize(deserializer: Deserializer) -> RawTransaction:

--- a/aptos_sdk/type_tag.py
+++ b/aptos_sdk/type_tag.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import typing
 import unittest
+from functools import lru_cache
 from typing import List, Tuple
 
 from .account_address import AccountAddress
@@ -306,6 +307,7 @@ class StructTag(Deserializable, Serializable):
         return value
 
     @staticmethod
+    @lru_cache(maxsize=256)
     def from_str(type_tag: str) -> StructTag:
         return StructTag._from_str_internal(type_tag, 0)[0][0].value
 

--- a/aptos_sdk/v2/bcs/serializer.py
+++ b/aptos_sdk/v2/bcs/serializer.py
@@ -154,7 +154,7 @@ class Serializer:
     ) -> None:
         self.uleb128(len(values))
         for value in values:
-            self.fixed_bytes(_encode(value, value_encoder))
+            value_encoder(self, value)
 
     def map(
         self,
@@ -162,14 +162,12 @@ class Serializer:
         key_encoder: Callable[[Serializer, Any], None],
         value_encoder: Callable[[Serializer, Any], None],
     ) -> None:
-        encoded_values = [
-            (_encode(key, key_encoder), _encode(val, value_encoder)) for key, val in values.items()
-        ]
-        encoded_values.sort(key=lambda item: item[0])
-        self.uleb128(len(encoded_values))
-        for key, val in encoded_values:
-            self.fixed_bytes(key)
-            self.fixed_bytes(val)
+        encoded_pairs = [(_encode(key, key_encoder), val) for key, val in values.items()]
+        encoded_pairs.sort(key=lambda item: item[0])
+        self.uleb128(len(encoded_pairs))
+        for encoded_key, val in encoded_pairs:
+            self.fixed_bytes(encoded_key)
+            value_encoder(self, val)
 
     @staticmethod
     def sequence_serializer(

--- a/aptos_sdk/v2/transactions/raw_transaction.py
+++ b/aptos_sdk/v2/transactions/raw_transaction.py
@@ -17,19 +17,8 @@ from .authenticator import (
 )
 from .payload import TransactionPayload
 
-
-def _raw_txn_prehash() -> bytes:
-    """SHA3-256 of b"APTOS::RawTransaction" — the domain separator for single-sender signing."""
-    hasher = hashlib.sha3_256()
-    hasher.update(b"APTOS::RawTransaction")
-    return hasher.digest()
-
-
-def _raw_txn_with_data_prehash() -> bytes:
-    """SHA3-256 of b"APTOS::RawTransactionWithData" — for multi-agent/fee-payer signing."""
-    hasher = hashlib.sha3_256()
-    hasher.update(b"APTOS::RawTransactionWithData")
-    return hasher.digest()
+_RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
+_RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
 
 
 def _sign_internal(keyed_data: bytes, key: PrivateKey) -> AccountAuthenticator:
@@ -98,9 +87,7 @@ class RawTransaction:
         """Produce the signing message: prehash || BCS(self)."""
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_prehash())
-        prehash.extend(ser.output())
-        return bytes(prehash)
+        return _RAW_TXN_PREHASH + ser.output()
 
     def sign(self, private_key: PrivateKey) -> AccountAuthenticator:
         return _sign_internal(self.keyed(), private_key)
@@ -150,9 +137,7 @@ class MultiAgentRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_with_data_prehash())
-        prehash.extend(ser.output())
-        return bytes(prehash)
+        return _RAW_TXN_WITH_DATA_PREHASH + ser.output()
 
     def sign(self, private_key: PrivateKey) -> AccountAuthenticator:
         return _sign_internal(self.keyed(), private_key)
@@ -197,9 +182,7 @@ class FeePayerRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_with_data_prehash())
-        prehash.extend(ser.output())
-        return bytes(prehash)
+        return _RAW_TXN_WITH_DATA_PREHASH + ser.output()
 
     def sign(self, private_key: PrivateKey) -> AccountAuthenticator:
         return _sign_internal(self.keyed(), private_key)

--- a/aptos_sdk/v2/types/type_tag.py
+++ b/aptos_sdk/v2/types/type_tag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from ..bcs import Deserializer, Serializer
 from ..errors import InvalidTypeTagError
@@ -217,6 +218,7 @@ class StructTag:
         return value
 
     @staticmethod
+    @lru_cache(maxsize=256)
     def from_str(type_tag: str) -> StructTag:
         tags, _ = _parse_type_tags(type_tag, 0)
         if not tags:  # pragma: no cover — parser always appends via _make_struct_tag


### PR DESCRIPTION
## Summary
- **BCS serializer**: Eliminate intermediate `Serializer` + `BytesIO` allocations in `sequence()` and `map()` — elements now write directly to the parent buffer instead of creating throwaway instances per item
- **Transaction signing**: Cache SHA3-256 prehash digests as module-level constants and replace `bytearray → extend → bytes` copies with simple `bytes` concatenation in `keyed()`
- **Type tag parsing**: Add `@lru_cache(maxsize=256)` to `StructTag.from_str()` to avoid re-parsing identical type tag strings

All changes are internal optimizations — no public API modifications. Output is byte-identical.

## Test plan
- [x] All 54 v1 unit tests pass
- [x] All 398 v2 unit tests pass
- [x] Corpus-based hex test vectors verify byte-identical signing output
- [x] ruff + mypy clean