### PR TITLE
Pin GitHub Actions and tighten workflow permissions

### DIFF
--- a/.github/actions/python-setup/action.yaml
+++ b/.github/actions/python-setup/action.yaml
@@ -17,18 +17,18 @@ runs:
   using: composite
   steps:
     - name: Setup python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
       with:
         python-version: ${{ inputs.python_version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
       with:
         enable-cache: true
         cache-dependency-glob: "**/uv.lock"
 
     - name: Setup AikidoSec Safe Chain
-      uses: aptos-labs/actions/aikidosec-safe-chain@main
+      uses: aptos-labs/actions/aikidosec-safe-chain@528ef7ad9427a8c0720ea3eea790a9190d6e377d
 
     - name: Install project
       if: inputs.pyproject_directory != ''

--- a/.github/workflows/devnet-examples.yaml
+++ b/.github/workflows/devnet-examples.yaml
@@ -24,6 +24,8 @@ jobs:
       FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_FAUCET_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/python-setup
         with:

--- a/.github/workflows/devnet-examples.yaml
+++ b/.github/workflows/devnet-examples.yaml
@@ -23,7 +23,7 @@ jobs:
       API_KEY: ${{ secrets.DEVNET_API_KEY }}
       FAUCET_AUTH_TOKEN: ${{ secrets.DEVNET_FAUCET_AUTH_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - uses: ./.github/actions/python-setup
         with:

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Run python setup
         uses: ./.github/actions/python-setup
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
         with:
           files: coverage.xml
           fail_ci_if_error: false

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -21,6 +21,8 @@ jobs:
         python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - name: Run python setup
         uses: ./.github/actions/python-setup

--- a/.github/workflows/localnet-examples.yaml
+++ b/.github/workflows/localnet-examples.yaml
@@ -24,10 +24,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - name: Checkout aptos-core
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
+          persist-credentials: false
           repository: aptos-labs/aptos-core
           path: './aptos-core'
 

--- a/.github/workflows/localnet-examples.yaml
+++ b/.github/workflows/localnet-examples.yaml
@@ -23,16 +23,16 @@ jobs:
       APTOS_TEST_USE_EXISTING_NETWORK: true
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Checkout aptos-core
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           repository: aptos-labs/aptos-core
           path: './aptos-core'
 
       - name: Run a localnet
-        uses: aptos-labs/actions/run-local-testnet@main
+        uses: aptos-labs/actions/run-local-testnet@528ef7ad9427a8c0720ea3eea790a9190d6e377d
         with:
           node_version: v22.14.0
           pnpm_version: 9.15.4

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/python-setup
         with:
@@ -36,6 +38,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/python-setup
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -12,14 +12,13 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
     name: Test before publish
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - uses: ./.github/actions/python-setup
         with:
@@ -36,7 +35,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - uses: ./.github/actions/python-setup
 
@@ -44,7 +43,7 @@ jobs:
         run: uv build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: dist
           path: dist/
@@ -56,13 +55,14 @@ jobs:
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
+      contents: read
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI via trusted publishing
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b

--- a/.github/workflows/v2-ci.yaml
+++ b/.github/workflows/v2-ci.yaml
@@ -34,6 +34,8 @@ jobs:
         working-directory: v2
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
         with:
@@ -67,6 +69,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        with:
+          persist-credentials: false
 
       - uses: ./.github/actions/python-setup
         with:

--- a/.github/workflows/v2-ci.yaml
+++ b/.github/workflows/v2-ci.yaml
@@ -33,20 +33,20 @@ jobs:
       run:
         working-directory: v2
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@e58605a9b6da7c637471fab8847a5e5a6b8df081
         with:
           enable-cache: true
           cache-dependency-glob: "v2/uv.lock"
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Setup AikidoSec Safe Chain
-        uses: aptos-labs/actions/aikidosec-safe-chain@main
+        uses: aptos-labs/actions/aikidosec-safe-chain@528ef7ad9427a8c0720ea3eea790a9190d6e377d
 
       - name: Install dependencies
         run: uv sync --extra dev
@@ -56,7 +56,7 @@ jobs:
 
       - name: Upload to Codecov
         if: always()
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe
         with:
           files: v2/coverage.xml
           flags: v2-sdk
@@ -66,7 +66,7 @@ jobs:
     name: V2 integrated import test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - uses: ./.github/actions/python-setup
         with:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description
Pin external GitHub Actions references to immutable commit SHAs and tighten workflow security posture.

Security audit notes:
- No `pull_request_target` workflows found.
- Existing workflow permissions are read-only except for PyPI trusted publishing OIDC.
- PyPI OIDC permission is scoped only to the publishing job.
- Devnet secrets remain guarded from forked pull requests by the existing job-level condition.
- `actions/checkout` credential persistence is disabled in all jobs.

### Test Plan
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/*.yaml`
- Custom Python scan asserting every external `uses:` ref under `.github` is pinned to a 40-character SHA
- `$HOME/.local/bin/zizmor .github/workflows .github/actions`
- `git diff --check HEAD~1`

### Related Links
N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b5f638f8-b54b-436f-8b4e-fe64ee7d2020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b5f638f8-b54b-436f-8b4e-fe64ee7d2020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

