### PR TITLE
SDK audit: lift coverage to 90%, fix 7 bugs, add E2E smoke + security review

### DIFF
--- a/.github/scripts/check_v2_sync.sh
+++ b/.github/scripts/check_v2_sync.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Verify the embedded `aptos_sdk/v2` mirror is byte-identical to the
+# standalone `v2/src/aptos_sdk_v2` package (excluding caches).
+#
+# Both copies must remain in sync because:
+#   * `from aptos_sdk.v2 import ...` ships in the main `aptos-sdk` wheel.
+#   * `aptos-python-sdk-v2` (in `v2/`) is the standalone package with its
+#     own version, tests, and CI (>98% coverage target).
+#
+# Without this check, fixes can land in one location but silently miss
+# the other (this happened historically — see CHANGELOG).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+MIRROR="${REPO_ROOT}/aptos_sdk/v2"
+SOURCE="${REPO_ROOT}/v2/src/aptos_sdk_v2"
+
+if ! diff -r --exclude=__pycache__ "${MIRROR}" "${SOURCE}" >/tmp/v2_sync_diff.txt 2>&1; then
+    echo "FAILURE: aptos_sdk/v2 and v2/src/aptos_sdk_v2 are out of sync." >&2
+    echo "Run: rsync -a --delete --exclude=__pycache__ v2/src/aptos_sdk_v2/ aptos_sdk/v2/" >&2
+    echo "(or copy in the opposite direction depending on which side has the fixes)." >&2
+    echo "" >&2
+    cat /tmp/v2_sync_diff.txt >&2
+    exit 1
+fi
+
+echo "OK: aptos_sdk/v2 mirrors v2/src/aptos_sdk_v2"

--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -54,3 +54,7 @@ jobs:
           flags: v1-sdk
           fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Verify v2 mirror is in sync
+        run: bash .github/scripts/check_v2_sync.sh
+        shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,14 @@ All notable changes to the Aptos Python SDK will be captured in this file. This 
 ## Unreleased
 - **[Breaking Change]**: Minimum supported Python is now 3.10 (required for patched dev tooling and alignment with Python 3.9 end-of-life).
 - **[Breaking Change]**: Replace `python-ecdsa` (CVE-2024-23342, pure-Python) with `cryptography` (OpenSSL-backed) for secp256k1 ECDSA operations. The public API is unchanged. Note: signing now uses OpenSSL's randomized nonce instead of RFC 6979 deterministic nonce — identical (key, message) pairs will produce different valid signatures on each call. `verify()` now rejects high-S signatures to match Aptos on-chain behaviour.
+- **[Breaking Change — v2 only, key derivation]**: `aptos_sdk_v2.crypto.mnemonic.derive_ed25519_private_key` and `derive_secp256k1_private_key` now require the full BIP-44 path `m/purpose'/coin'/account'/change'/address'` and read the address index from segment 5 (`parts[5]`). The previous implementation read the *change* segment (`parts[4]`) as the address index and never called `.AddressIndex(...)`, so any non-zero address index was silently ignored and **every** mnemonic-derived account collapsed onto the index-0 key. After this fix, paths with a non-zero address index will derive a different private key (and therefore a different account address) than the old, broken code did. Users with on-chain state derived from a non-zero address index under the old code must migrate; users on the canonical `m/44'/637'/0'/0'/0'` path are unaffected.
 - Update dependencies for vulnerability fixes (`aiohttp`, `urllib3`, `PyNaCl`, `black`).
 - Apply Black 26 formatting across `aptos_sdk`, `examples`, and `features` stubs (required by CI `make fmt` gate).
 - CI: pin Python 3.12 in the composite setup action; use `actions/checkout@v5` and `actions/setup-python@v5`.
 - Increase default `max_gas_amount` from 100,000 to 1,000,000
+- Add `aptos_sdk_v2.types.TypeTag.from_str` parser supporting primitives (`bool`, `u8`–`u256`, `address`, `signer`), `vector<T>`, and structs. `GeneralApi.view_bcs` now uses it, so view functions with non-struct generics (e.g. `0x1::coin::balance<u64>`) work correctly.
+- Stricter `aptos_sdk_v2.transactions.payload.ModuleId.from_str` — rejects malformed inputs (wrong number of `::` separators, empty address, or empty module name) at parse time instead of failing later during BCS serialization.
+- Stricter `aptos_sdk.async_client.IndexerClient.query` exception scope — only wraps known transport / decoding errors (`aiohttp.ClientError`, `asyncio.TimeoutError`, `json.JSONDecodeError`, `UnicodeDecodeError`) into `IndexerError`. Caller bugs (`TypeError`, `AttributeError`, etc.) propagate unchanged.
 
 ## 0.11.0
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ lint:
 
 examples:
 	uv run python -m examples.aptos_token
+	uv run python -m examples.e2e_smoke
 	uv run python -m examples.fee_payer_transfer_coin
 	uv run python -m examples.multikey
 	uv run python -m examples.rotate_key
@@ -34,6 +35,9 @@ examples:
 	uv run python -m examples.simulate_transfer_coin
 	uv run python -m examples.transfer_coin
 	uv run python -m examples.transfer_two_by_two
+
+smoke:
+	uv run python -m examples.e2e_smoke
 
 examples_cli:
 	uv run python -m examples.hello_blockchain
@@ -48,4 +52,4 @@ integration_test:
 pre-commit: fmt lint
 	@./.github/scripts/fail_if_modified_files.sh
 
-.PHONY: examples fmt lint pre-commit test test-coverage test-spec
+.PHONY: examples fmt lint pre-commit smoke test test-coverage test-spec

--- a/README.md
+++ b/README.md
@@ -67,6 +67,28 @@ uv sync --extra dev
 make test
 ```
 
+### Quick devnet smoke test
+
+A single command that verifies node, faucet, transaction submission, simulation,
+balance reads, and indexer (gracefully skipped on rate-limit) all work end-to-end:
+
+```bash
+make smoke           # uses public devnet by default
+APTOS_NODE_URL=http://127.0.0.1:8080/v1 \
+APTOS_FAUCET_URL=http://127.0.0.1:8081  \
+make smoke           # against a local testnet
+```
+
+### Test coverage
+
+```bash
+make test-coverage
+```
+
+The legacy `aptos_sdk/` package targets ≥ 90 % unit-test coverage. The standalone
+v2 package under `v2/` targets ≥ 95 %. Coverage from both is uploaded to
+[Codecov][codecov-url] under the `v1-sdk` and `v2-sdk` flags respectively.
+
 ### E2E testing and Using the Aptos CLI
 
 * Download and install the [Aptos CLI](https://aptos.dev/tools/aptos-cli/use-cli/running-a-local-network).

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -1,0 +1,136 @@
+# Aptos Python SDK — Security Review
+
+Date: 2026-05-15
+Scope: `aptos_sdk/` (legacy v1 package), `v2/src/aptos_sdk_v2/` (standalone
+v2 package), `examples/`, CI workflows, and packaging metadata.
+Methodology: manual code review of every module, dependency surface analysis,
+diff between the two v2 trees, runtime testing against devnet.
+
+This document is informational and supersedes nothing in `SECURITY.md`. Report
+true vulnerabilities through the channel defined there, not via PR.
+
+---
+
+## 1. Threat model
+
+The SDK runs in a **trusted client process**: the user controls the host, the
+private keys, and the network destination. Adversaries we care about are:
+
+| # | Adversary | Plausible attack |
+|---|-----------|------------------|
+| A1 | Compromised dependency | Steal private keys at signing time, inject malicious BCS |
+| A2 | Hostile RPC node | Return crafted JSON / BCS that crashes the client or causes incorrect signatures |
+| A3 | Hostile faucet | Replay / mint to attacker addresses (out of scope for the SDK; the faucet is the trust root for funding on devnet/testnet) |
+| A4 | MITM on HTTPS | TLS downgrade, cert tampering — relies on `httpx` defaults |
+| A5 | Local file disclosure | Private-key JSON files left world-readable (`Account.store`) |
+| A6 | Re-entrancy / reuse | Replay of a signed transaction |
+
+The SDK does **not** defend against a compromised host or against an attacker
+who already has the user's private key. Out of scope.
+
+---
+
+## 2. Findings
+
+### 2.1 Resolved by this PR
+
+| ID | Severity | Module | Issue | Fix |
+|----|----------|--------|-------|-----|
+| F-01 | **High** (correctness) | `aptos_sdk/transactions.py` | `ScriptArgument.__init__` rejected variants 6 (U16), 7 (U32), 8 (U256) even though `serialize`/`deserialize` supported them. Any caller passing a U16/U32/U256 script argument got `InvalidTypeError` at construction time, while bytes deserialized from chain crashed only on a later round-trip. | Widen variant range to `[0, 8]` and improve the error message. |
+| F-02 | Medium | `aptos_sdk/asymmetric_crypto_wrapper.py` | `PublicKey.deserialize` checked `Signature.SECP256K1_ECDSA` rather than `PublicKey.SECP256K1_ECDSA`. Worked by accident (both equal `1`), but a future renumbering would silently accept invalid bytes. | Use the correct constant. |
+| F-03 | Medium | `aptos_sdk/async_client.py` | `IndexerClient.query` propagated raw `aiohttp.ContentTypeError` when the indexer returned an HTML rate-limit page. Clients had no way to catch this generically. | Wrap in a new `IndexerError`; also raise `IndexerError` when the GraphQL response has a top-level `errors` array. |
+| F-04 | Low | `aptos_sdk/async_client.py` | `FaucetClient.healthy` returned truthy for any 5xx response with body containing `tap:ok` (and crashed on transport errors). | Require `status_code == 200` and swallow `httpx.HTTPError` to return `False`. |
+| F-05 | Low | `aptos_sdk/v2` mirror divergence | `aptos_sdk/v2/` had safety improvements (BIP-44 path validation, secp256k1 wrapping in `AuthenticationKey.from_public_key`, `ModuleId.from_str` validation) that were missing from `v2/src/aptos_sdk_v2/`. End users importing from the standalone package received the unsafe versions. | Port the fixes back to `v2/src/aptos_sdk_v2/`; add `.github/scripts/check_v2_sync.sh` and CI step to enforce mirror parity. |
+| F-06 | Low | `examples/transaction_batching.py` | `Accounts.generate("nodes", ...)` crashed with `FileNotFoundError` because the `nodes/` directory was never created. Affects any user copy-pasting the example. | `os.makedirs(path, exist_ok=True)`. |
+| F-07 | Informational | `examples/fee_payer_transfer_coin.py` | Comment said "Have Alice give Bob 1_000 coins" but the entry function actually called is `0x1::aptos_account::create_account` — no coins are transferred. | Comment corrected. |
+
+### 2.2 Pre-existing risks worth noting
+
+| ID | Severity | Module | Issue | Recommendation |
+|----|----------|--------|-------|----------------|
+| O-01 | Medium | `aptos_sdk/account.py` | `Account.store` writes the private key as plaintext JSON with default permissions (typically 0644 on Linux). Any user on the box can read it. | Document the risk; consider `os.chmod(path, 0o600)` and a warning log line. |
+| O-02 | Medium | `aptos_sdk/asymmetric_crypto_wrapper.MultiPublicKey` | The `MultiPublicKey.verify` path does **not** ensure the same signer index isn't counted twice — a forged `MultiSignature` containing the same valid `(idx, sig)` twice would pass. | Add `seen = set()` deduplication; reject `idx >= len(keys)` (already done) and require unique indices. |
+| O-03 | Medium | `aptos_sdk/async_client.RestClient` | All HTTP/2 connections share a single `httpx.AsyncClient` with no per-call API key rotation. `Authorization` is set once at client-construction time. If a long-lived process needs to rotate keys it has to construct a new client. | Document; consider exposing `set_api_key()`. |
+| O-04 | Low | `aptos_sdk/async_client.RestClient.transaction_pending` | Treats HTTP 404 as "still pending" so `wait_for_transaction` will silently spin on a typo'd hash until it times out. | Bound the 404 grace window (e.g. accept 404 only for the first N polls, then escalate). |
+| O-05 | Low | `aptos_sdk/async_client.RestClient` | No per-call timeout. Pool timeout is `None` ("wait forever for a slot"). A single hung request will block all subsequent ones. | Add a per-request timeout argument or align pool timeout with `transaction_wait_in_seconds`. |
+| O-06 | Low | `aptos_sdk/aptos_cli_wrapper.py` | `CLIError.__init__` joins the entire `args` list (including potentially sensitive values like `--private-key-path`) into the exception message. | Redact `--private-key*` flags before logging. |
+| O-07 | Low | `aptos_sdk/cli.py` | Reads private key from a path supplied via `--private-key-path` but doesn't check file permissions before opening. | Optional: warn if file is world-readable. |
+| O-08 | Low | `aptos_sdk/transactions.py` | `RawTransaction` accepts arbitrary integer values for `chain_id` (u8 only). On a typo (e.g. `chain_id=1024`) BCS serialization will silently truncate or raise far from the source of the bug. | Validate `0 <= chain_id < 256` in `__init__`. |
+| O-09 | Informational | `aptos_sdk/async_client.IndexerClient` | Bearer tokens are passed via the constructor and stored on the underlying GraphQL client headers. No secret-scrubbing on `__repr__`. | Override `__repr__` to redact. |
+
+### 2.3 Dependency surface
+
+`pyproject.toml` already pins minimum-secure floors for indirect dependencies
+(`h11>=0.16.0`, `urllib3>=2.6.3`, `requests>=2.32.5`, `aiohttp>=3.13.3`).
+That's good practice; keep these floors moving forward.
+
+`bip-utils` (used by v2 mnemonic derivation) transitively pulls in
+`coincurve`, which is a `setup.py`-style C-extension package. The v2 README
+already flags `bip-utils` as the next dep to evict; coincurve in particular
+has had a history of releasing wheels late on each Python minor bump and is
+a useful target for supply-chain attackers because it's tiny and unaudited.
+We replaced direct secp256k1 with `cryptography` in v2 — finishing the
+`bip-utils` removal would close that surface entirely.
+
+`python-graphql-client` (used by `IndexerClient`) is a thin wrapper over
+`aiohttp` that hasn't seen a release in a long time. Consider replacing with
+direct `httpx.AsyncClient.post`.
+
+### 2.4 Cryptographic notes
+
+* **Ed25519** — backed by PyNaCl (libsodium). No issues found.
+* **Secp256k1** — backed by `cryptography` (OpenSSL via `hazmat`). Signing
+  uses deterministic ECDSA per RFC 6979 (default in `cryptography`).
+  ✅ Good.
+* **Authentication-key derivation** — uses SHA3-256 with the documented
+  scheme bytes (Ed25519=0x00, MultiEd25519=0x01, SingleKey=0x02,
+  MultiKey=0x03). Matches the on-chain definition in `aptos-core`.
+* **Domain separators** — `APTOS::RawTransaction` (single-signer) and
+  `APTOS::RawTransactionWithData` (multi-agent / fee-payer) match
+  `aptos-core`. Verified by the corpus tests in `aptos_sdk/transactions.py`.
+* **Simulated-transaction signatures** are 64 zero bytes. The SDK correctly
+  rejects them on `SignedTransaction.verify` so users cannot accidentally
+  ship an unsigned transaction. ✅ Tested.
+
+### 2.5 Network & TLS
+
+* Default `httpx.AsyncClient` config trusts the system CA bundle and uses
+  TLS 1.2+. Acceptable for the Aptos public endpoints which are HTTPS.
+* HTTP/2 is enabled by default (`ClientConfig.http2 = True`). HTTP/2
+  upgrade is opportunistic; downgrade attacks aren't trivially exploitable.
+* The faucet and node URLs are taken from environment variables in
+  `examples/common.py`. Users running examples in a CI environment should
+  not export these to untrusted hosts.
+
+### 2.6 What this SDK explicitly does **not** do
+
+* It does not store, encrypt, or rotate private keys. `Account.store` writes
+  cleartext JSON for convenience — production users should integrate with
+  their own secrets manager (AWS Secrets Manager, GCP Secret Manager, HSM).
+* It does not enforce any kind of replay protection beyond what the on-chain
+  sequence number / orderless nonce provides.
+* It does not validate that the configured RPC endpoint is on the chain the
+  user expects beyond exposing `chain_id()`. Callers should pin a chain ID
+  for production deployments.
+
+---
+
+## 3. Recommended follow-ups
+
+The fixes in §2.1 land with this PR. The items in §2.2 are tracked here for a
+follow-up PR / issue. In rough priority order:
+
+1. **O-02** (MultiPublicKey replay): real signature-bypass vector if anyone
+   wires the v1 SDK into a multi-sig server. High priority.
+2. **O-04 / O-05**: hardening of the wait/timeout machinery so long-lived
+   services don't deadlock on bad inputs.
+3. **O-01 / O-07**: file-permission hygiene around `Account.store` and
+   `--private-key-path`.
+4. **O-08**: range checks on `RawTransaction` integer fields so user
+   typos surface at the source.
+5. Replace `python-graphql-client` and finish removing `bip-utils` from the
+   v2 install surface (already flagged in `pyproject.toml`).
+6. Reproducible build / wheel signing — currently `hatchling` builds wheels
+   but they are not signed (Sigstore / `attestations`). Worth adding to
+   `.github/workflows/publish.yaml` once a maintainer sets up a Sigstore
+   identity.

--- a/SECURITY_REVIEW.md
+++ b/SECURITY_REVIEW.md
@@ -80,8 +80,10 @@ direct `httpx.AsyncClient.post`.
 
 * **Ed25519** — backed by PyNaCl (libsodium). No issues found.
 * **Secp256k1** — backed by `cryptography` (OpenSSL via `hazmat`). Signing
-  uses deterministic ECDSA per RFC 6979 (default in `cryptography`).
-  ✅ Good.
+  uses OpenSSL's default randomized ECDSA nonce (not RFC 6979); identical
+  (key, message) pairs produce different valid signatures on each call.
+  See CHANGELOG for migration context. High-S signatures are rejected on
+  `verify()` to match Aptos on-chain behaviour. ✅ Acceptable.
 * **Authentication-key derivation** — uses SHA3-256 with the documented
   scheme bytes (Ed25519=0x00, MultiEd25519=0x01, SingleKey=0x02,
   MultiKey=0x03). Matches the on-chain definition in `aptos-core`.

--- a/aptos_sdk/account_sequence_number.py
+++ b/aptos_sdk/account_sequence_number.py
@@ -167,8 +167,15 @@ class Test(unittest.IsolatedAsyncioTestCase):
             "aptos_sdk.async_client.RestClient.account_sequence_number", return_value=0
         )
         patcher.start()
+        # `synchronize` reads `current_timestamp()` (which talks to the node) for
+        # its time-budget check; stub it so the test is fully hermetic.
+        timestamp_patcher = unittest.mock.patch(
+            "aptos_sdk.async_client.RestClient.current_timestamp", return_value=0.0
+        )
+        timestamp_patcher.start()
 
-        rest_client = RestClient("https://fullnode.devnet.aptoslabs.com/v1")
+        # Use a placeholder URL — the test never makes a real HTTP call.
+        rest_client = RestClient("http://localhost:65535")
         account_sequence_number = AccountSequenceNumber(rest_client, AccountAddress.from_str("0xf"))
         last_seq_num = 0
         for seq_num in range(5):
@@ -197,3 +204,5 @@ class Test(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(account_sequence_number._current_number, last_seq_num)
         await account_sequence_number.synchronize()
         self.assertEqual(account_sequence_number._current_number, next_sequence_number)
+        patcher.stop()
+        timestamp_patcher.stop()

--- a/aptos_sdk/account_sequence_number.py
+++ b/aptos_sdk/account_sequence_number.py
@@ -163,16 +163,20 @@ class Test(unittest.IsolatedAsyncioTestCase):
         * Ensure that none is returned if the call for next_sequence_number would block
         * Ensure that synchronize completes if the value matches on-chain
         """
-        patcher = unittest.mock.patch(
-            "aptos_sdk.async_client.RestClient.account_sequence_number", return_value=0
-        )
-        patcher.start()
-        # `synchronize` reads `current_timestamp()` (which talks to the node) for
-        # its time-budget check; stub it so the test is fully hermetic.
+        # Use addCleanup for each patcher so they're stopped even if the test fails
+        # partway through. patcher.stop() is idempotent so the explicit mid-test
+        # stop() calls (needed to swap return values) are still safe.
         timestamp_patcher = unittest.mock.patch(
             "aptos_sdk.async_client.RestClient.current_timestamp", return_value=0.0
         )
         timestamp_patcher.start()
+        self.addCleanup(timestamp_patcher.stop)
+
+        patcher = unittest.mock.patch(
+            "aptos_sdk.async_client.RestClient.account_sequence_number", return_value=0
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
 
         # Use a placeholder URL — the test never makes a real HTTP call.
         rest_client = RestClient("http://localhost:65535")
@@ -187,6 +191,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
             "aptos_sdk.async_client.RestClient.account_sequence_number", return_value=5
         )
         patcher.start()
+        self.addCleanup(patcher.stop)
 
         for seq_num in range(AccountSequenceNumber._maximum_in_flight):
             last_seq_num = await account_sequence_number.next_sequence_number()
@@ -200,6 +205,7 @@ class Test(unittest.IsolatedAsyncioTestCase):
             return_value=next_sequence_number,
         )
         patcher.start()
+        self.addCleanup(patcher.stop)
 
         self.assertNotEqual(account_sequence_number._current_number, last_seq_num)
         await account_sequence_number.synchronize()

--- a/aptos_sdk/account_sequence_number.py
+++ b/aptos_sdk/account_sequence_number.py
@@ -210,5 +210,4 @@ class Test(unittest.IsolatedAsyncioTestCase):
         self.assertNotEqual(account_sequence_number._current_number, last_seq_num)
         await account_sequence_number.synchronize()
         self.assertEqual(account_sequence_number._current_number, next_sequence_number)
-        patcher.stop()
-        timestamp_patcher.stop()
+        # addCleanup handles teardown — no explicit stops needed here.

--- a/aptos_sdk/asymmetric_crypto_wrapper.py
+++ b/aptos_sdk/asymmetric_crypto_wrapper.py
@@ -43,7 +43,7 @@ class PublicKey(asymmetric_crypto.PublicKey):
 
         if variant == PublicKey.ED25519:
             public_key: asymmetric_crypto.PublicKey = ed25519.PublicKey.deserialize(deserializer)
-        elif variant == Signature.SECP256K1_ECDSA:
+        elif variant == PublicKey.SECP256K1_ECDSA:
             public_key = secp256k1_ecdsa.PublicKey.deserialize(deserializer)
         else:
             raise InvalidTypeError(f"Invalid type: {variant}")

--- a/aptos_sdk/async_client.py
+++ b/aptos_sdk/async_client.py
@@ -41,7 +41,7 @@ class ClientConfig:
 
 
 class IndexerClient:
-    """A wrapper around the Aptos Indexer Service on Hasura"""
+    """A wrapper around the Aptos Indexer Service on Hasura."""
 
     client: python_graphql_client.GraphqlClient
 
@@ -52,7 +52,19 @@ class IndexerClient:
         self.client = python_graphql_client.GraphqlClient(endpoint=indexer_url, headers=headers)
 
     async def query(self, query: str, variables: Dict[str, Any]) -> Dict[str, Any]:
-        return await self.client.execute_async(query, variables)
+        """Execute a GraphQL query against the indexer.
+
+        Raises:
+            IndexerError: If the indexer returns a non-JSON response (e.g. a
+                rate-limit HTML body) or includes a top-level ``errors`` array.
+        """
+        try:
+            result = await self.client.execute_async(query, variables)
+        except Exception as exc:  # aiohttp.ContentTypeError on rate limit, etc.
+            raise IndexerError(f"indexer query failed: {exc}") from exc
+        if isinstance(result, dict) and result.get("errors"):
+            raise IndexerError(f"indexer returned errors: {result['errors']}")
+        return result
 
 
 class RestClient:
@@ -982,8 +994,12 @@ class FaucetClient:
         return txn_hash
 
     async def healthy(self) -> bool:
-        response = await self.rest_client.client.get(self.base_url)
-        return "tap:ok" == response.text
+        """Return ``True`` iff the faucet's root endpoint reports ``tap:ok``."""
+        try:
+            response = await self.rest_client.client.get(self.base_url)
+        except httpx.HTTPError:
+            return False
+        return response.status_code == 200 and response.text == "tap:ok"
 
 
 class ApiError(Exception):
@@ -1025,3 +1041,7 @@ class TransactionTimeout(Exception):
 
 class TransactionFailed(Exception):
     """The transaction completed but was not successful"""
+
+
+class IndexerError(Exception):
+    """The indexer returned an error or a non-JSON response (e.g., when rate-limited)."""

--- a/aptos_sdk/async_client.py
+++ b/aptos_sdk/async_client.py
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json as _json
 import logging
 import time
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
+import aiohttp
 import httpx
 import python_graphql_client
 
@@ -55,12 +57,19 @@ class IndexerClient:
         """Execute a GraphQL query against the indexer.
 
         Raises:
-            IndexerError: If the indexer returns a non-JSON response (e.g. a
-                rate-limit HTML body) or includes a top-level ``errors`` array.
+            IndexerError: If the indexer is unreachable, times out, returns a
+                non-JSON response (e.g. a rate-limit HTML body), or includes a
+                top-level ``errors`` array. Other exception types — programming
+                errors, ``KeyboardInterrupt``, etc. — propagate unchanged.
         """
         try:
             result = await self.client.execute_async(query, variables)
-        except Exception as exc:  # aiohttp.ContentTypeError on rate limit, etc.
+        except (
+            aiohttp.ClientError,  # network / HTTP / decode errors from aiohttp
+            asyncio.TimeoutError,
+            _json.JSONDecodeError,
+            UnicodeDecodeError,
+        ) as exc:
             raise IndexerError(f"indexer query failed: {exc}") from exc
         if isinstance(result, dict) and result.get("errors"):
             raise IndexerError(f"indexer returned errors: {result['errors']}")

--- a/aptos_sdk/extra_test.py
+++ b/aptos_sdk/extra_test.py
@@ -320,15 +320,30 @@ class IndexerClientTests(unittest.TestCase):
             _run(client.query("{x}", {}))
 
     def test_query_wraps_transport_error(self):
+        import aiohttp
+
         client = IndexerClient("http://mock.invalid/graphql", bearer_token="t")
 
         async def fake_query(query, variables):
-            raise RuntimeError("rate limit")
+            # Simulate the real failure mode: indexer returns HTML on rate-limit
+            # and aiohttp raises ContentTypeError when we ask for JSON.
+            raise aiohttp.ClientError("rate limit")
 
         client.client.execute_async = fake_query  # type: ignore[assignment]
         with self.assertRaises(IndexerError) as ctx:
             _run(client.query("{x}", {}))
         self.assertIn("rate limit", str(ctx.exception))
+
+    def test_query_does_not_swallow_programmer_errors(self):
+        """Bugs in the caller (e.g. TypeError) must propagate, not become IndexerError."""
+        client = IndexerClient("http://mock.invalid/graphql")
+
+        async def fake_query(query, variables):
+            raise TypeError("oops, unhashable variables")
+
+        client.client.execute_async = fake_query  # type: ignore[assignment]
+        with self.assertRaises(TypeError):
+            _run(client.query("{x}", {}))
 
     def test_bearer_token_is_set(self):
         client = IndexerClient("http://mock.invalid/graphql", bearer_token="secret")

--- a/aptos_sdk/extra_test.py
+++ b/aptos_sdk/extra_test.py
@@ -1,0 +1,1578 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Extra unit tests for the legacy v1 SDK modules.
+
+These tests target previously-uncovered code paths so that ``make test-coverage``
+produces a more accurate picture of what's actually exercised. They are placed
+in a ``*_test.py`` file (matching the coverage ``omit`` glob in
+``pyproject.toml``) so the test code itself does not inflate coverage numbers.
+
+Network-dependent paths are exercised via an ``httpx.MockTransport`` rather
+than real devnet calls, keeping ``make test`` hermetic and fast.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import tempfile
+import unittest
+from typing import Callable
+from unittest import mock
+
+import httpx
+
+from . import asymmetric_crypto_wrapper, ed25519, secp256k1_ecdsa
+from .account import Account
+from .account_address import AccountAddress
+from .aptos_token_client import (
+    AptosTokenClient,
+    Collection,
+    InvalidPropertyType,
+    Object,
+    Property,
+    PropertyMap,
+    ReadObject,
+    Royalty,
+    Token,
+)
+from .aptos_tokenv1_client import AptosTokenV1Client
+from .async_client import (
+    AccountNotFound,
+    ApiError,
+    ClientConfig,
+    FaucetClient,
+    IndexerClient,
+    IndexerError,
+    ResourceNotFound,
+    RestClient,
+    TransactionFailed,
+    TransactionTimeout,
+)
+from .authenticator import (
+    Authenticator,
+    Ed25519Authenticator,
+    FeePayerAuthenticator,
+    MultiAgentAuthenticator,
+    SingleSenderAuthenticator,
+)
+from .bcs import Deserializer, Serializer
+from .cli import key_value
+from .errors import InvalidTypeError
+from .package_publisher import (
+    MAX_TRANSACTION_SIZE,
+    OBJECT_CODE_DEPLOYMENT_DOMAIN_SEPARATOR,
+    PackagePublisher,
+    PublishMode,
+)
+from .transactions import (
+    EntryFunction,
+    ModuleId,
+    RawTransaction,
+    Script,
+    ScriptArgument,
+    SignedTransaction,
+    TransactionArgument,
+    TransactionPayload,
+)
+from .type_tag import (
+    AccountAddressTag,
+    BoolTag,
+    StructTag,
+    TypeTag,
+    U8Tag,
+    U16Tag,
+    U32Tag,
+    U64Tag,
+    U128Tag,
+    U256Tag,
+)
+
+
+def _build_rest_client(
+    handler: Callable[[httpx.Request], httpx.Response],
+    *,
+    base_url: str = "http://mock.invalid/v1",
+) -> RestClient:
+    """Construct a RestClient whose underlying httpx.AsyncClient is mocked."""
+    client = RestClient(base_url, ClientConfig(http2=False, transaction_wait_in_seconds=2))
+    _run(client.client.aclose())
+    transport = httpx.MockTransport(handler)
+    client.client = httpx.AsyncClient(base_url="", transport=transport)
+    return client
+
+
+def _run(coro):
+    """Run a coroutine in a fresh, properly-closed event loop."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+SAMPLE_ADDR = "0x0000000000000000000000000000000000000000000000000000000000000a11"
+
+
+class ScriptArgumentTests(unittest.TestCase):
+    def test_all_variants_round_trip(self):
+        addr = AccountAddress.from_str_relaxed("0x42")
+        cases = [
+            ScriptArgument(ScriptArgument.U8, 17),
+            ScriptArgument(ScriptArgument.U16, 17000),
+            ScriptArgument(ScriptArgument.U32, 1_700_000),
+            ScriptArgument(ScriptArgument.U64, 17_000_000_000),
+            ScriptArgument(ScriptArgument.U128, 1 << 100),
+            ScriptArgument(ScriptArgument.U256, 1 << 200),
+            ScriptArgument(ScriptArgument.ADDRESS, addr),
+            ScriptArgument(ScriptArgument.U8_VECTOR, b"\x01\x02\x03"),
+            ScriptArgument(ScriptArgument.BOOL, True),
+        ]
+        for arg in cases:
+            ser = Serializer()
+            arg.serialize(ser)
+            de = Deserializer(ser.output())
+            round = ScriptArgument.deserialize(de)
+            self.assertEqual(arg, round)
+            self.assertIn(str(arg.variant), str(arg))
+
+    def test_invalid_variant_raises(self):
+        with self.assertRaises(InvalidTypeError):
+            ScriptArgument(99, 0)
+        with self.assertRaises(InvalidTypeError):
+            ScriptArgument(-1, 0)
+
+
+class ScriptRoundTripTests(unittest.TestCase):
+    def test_script_serializes_and_compares(self):
+        s1 = Script(b"\xde\xad\xbe\xef", [], [ScriptArgument(ScriptArgument.U64, 1)])
+        ser = Serializer()
+        s1.serialize(ser)
+        s2 = Script.deserialize(Deserializer(ser.output()))
+        self.assertEqual(s1, s2)
+        self.assertNotEqual(s1, "not a script")
+        # Script has __str__ that includes ty_args / args representations.
+        self.assertIn("<", str(s1))
+
+    def test_script_payload_round_trip(self):
+        payload = TransactionPayload(Script(b"\x00", [], []))
+        ser = Serializer()
+        payload.serialize(ser)
+        out = TransactionPayload.deserialize(Deserializer(ser.output()))
+        self.assertEqual(payload, out)
+        self.assertEqual(payload.variant, TransactionPayload.SCRIPT)
+
+
+class TransactionPayloadInvalidTypeTests(unittest.TestCase):
+    def test_invalid_payload_type_raises(self):
+        with self.assertRaises(InvalidTypeError):
+            TransactionPayload(object())
+
+    def test_payload_eq_other_type(self):
+        p = TransactionPayload(Script(b"", [], []))
+        self.assertNotEqual(p, "not a payload")
+
+
+class ModuleIdTests(unittest.TestCase):
+    def test_module_id_round_trip(self):
+        mid = ModuleId.from_str("0x1::aptos_account")
+        self.assertEqual(str(mid), "0x1::aptos_account")
+        self.assertEqual(mid, ModuleId.from_str("0x1::aptos_account"))
+        self.assertNotEqual(mid, "x")
+        ser = Serializer()
+        mid.serialize(ser)
+        out = ModuleId.deserialize(Deserializer(ser.output()))
+        self.assertEqual(mid, out)
+
+
+class TypeTagTests(unittest.TestCase):
+    def test_primitive_tag_round_trips(self):
+        cases = [
+            TypeTag(BoolTag(True)),
+            TypeTag(U8Tag(7)),
+            TypeTag(U16Tag(7)),
+            TypeTag(U32Tag(7)),
+            TypeTag(U64Tag(7)),
+            TypeTag(U128Tag(7)),
+            TypeTag(U256Tag(7)),
+            TypeTag(AccountAddressTag(AccountAddress.from_str_relaxed("0x1"))),
+        ]
+        for tag in cases:
+            ser = Serializer()
+            tag.serialize(ser)
+            out = TypeTag.deserialize(Deserializer(ser.output()))
+            self.assertEqual(tag, out)
+            self.assertEqual(repr(tag), str(tag))
+            self.assertNotEqual(tag, "not a tag")
+            self.assertNotEqual(tag.value, "not equal")
+
+    def test_struct_tag_with_type_args(self):
+        tag = StructTag.from_str("0x1::coin::Coin<0x1::aptos_coin::AptosCoin>")
+        self.assertEqual(
+            str(tag),
+            "0x1::coin::Coin<0x1::aptos_coin::AptosCoin>",
+        )
+        round = StructTag.from_bytes(tag.to_bytes())
+        self.assertEqual(tag, round)
+        self.assertNotEqual(tag, "x")
+
+    def test_signer_and_vector_unimplemented(self):
+        ser = Serializer()
+        ser.uleb128(TypeTag.SIGNER)
+        with self.assertRaises(NotImplementedError):
+            TypeTag.deserialize(Deserializer(ser.output()))
+        ser = Serializer()
+        ser.uleb128(TypeTag.VECTOR)
+        with self.assertRaises(NotImplementedError):
+            TypeTag.deserialize(Deserializer(ser.output()))
+
+
+class AsymmetricCryptoWrapperTests(unittest.TestCase):
+    def test_ed25519_round_trip(self):
+        sk = ed25519.PrivateKey.random()
+        pk = asymmetric_crypto_wrapper.PublicKey(sk.public_key())
+        sig = asymmetric_crypto_wrapper.Signature(sk.sign(b"hello"))
+        self.assertTrue(pk.verify(b"hello", sig))
+
+        ser = Serializer()
+        pk.serialize(ser)
+        out = asymmetric_crypto_wrapper.PublicKey.deserialize(Deserializer(ser.output()))
+        self.assertEqual(out.variant, asymmetric_crypto_wrapper.PublicKey.ED25519)
+
+        ser = Serializer()
+        sig.serialize(ser)
+        sig_out = asymmetric_crypto_wrapper.Signature.deserialize(Deserializer(ser.output()))
+        self.assertEqual(sig_out.variant, asymmetric_crypto_wrapper.Signature.ED25519)
+
+    def test_secp256k1_round_trip(self):
+        sk = secp256k1_ecdsa.PrivateKey.random()
+        pk = asymmetric_crypto_wrapper.PublicKey(sk.public_key())
+        sig = asymmetric_crypto_wrapper.Signature(sk.sign(b"hello"))
+        self.assertTrue(pk.verify(b"hello", sig))
+
+        ser = Serializer()
+        pk.serialize(ser)
+        out = asymmetric_crypto_wrapper.PublicKey.deserialize(Deserializer(ser.output()))
+        self.assertEqual(out.variant, asymmetric_crypto_wrapper.PublicKey.SECP256K1_ECDSA)
+        # The deserialized wrapped public key should match the input bytes.
+        self.assertEqual(out.public_key.to_crypto_bytes(), sk.public_key().to_crypto_bytes())
+
+    def test_invalid_variant_raises(self):
+        with self.assertRaises(NotImplementedError):
+            asymmetric_crypto_wrapper.PublicKey("not a key")  # type: ignore[arg-type]
+        with self.assertRaises(NotImplementedError):
+            asymmetric_crypto_wrapper.Signature("not a sig")  # type: ignore[arg-type]
+
+    def test_invalid_deserialized_variant(self):
+        ser = Serializer()
+        ser.uleb128(99)
+        ser.u8(0)
+        with self.assertRaises(InvalidTypeError):
+            asymmetric_crypto_wrapper.PublicKey.deserialize(Deserializer(ser.output()))
+        ser = Serializer()
+        ser.uleb128(99)
+        ser.u8(0)
+        with self.assertRaises(InvalidTypeError):
+            asymmetric_crypto_wrapper.Signature.deserialize(Deserializer(ser.output()))
+
+    def test_multi_public_key_validation(self):
+        sk = ed25519.PrivateKey.random()
+        pk = asymmetric_crypto_wrapper.PublicKey(sk.public_key())
+        with self.assertRaises(ValueError):
+            asymmetric_crypto_wrapper.MultiPublicKey([pk], 1)
+        with self.assertRaises(ValueError):
+            asymmetric_crypto_wrapper.MultiPublicKey([pk] * 33, 1)
+        with self.assertRaises(ValueError):
+            asymmetric_crypto_wrapper.MultiPublicKey([pk, pk], 0)
+        ok = asymmetric_crypto_wrapper.MultiPublicKey([pk, pk], 2)
+        self.assertEqual(ok.threshold, 2)
+        self.assertEqual(str(ok), "2-of-2 Multi key")
+
+    def test_multi_signature_round_trip(self):
+        sk = ed25519.PrivateKey.random()
+        sig = asymmetric_crypto_wrapper.Signature(sk.sign(b"x"))
+        ms = asymmetric_crypto_wrapper.MultiSignature([(0, sig), (3, sig)])
+        ser = Serializer()
+        ms.serialize(ser)
+        out = asymmetric_crypto_wrapper.MultiSignature.deserialize(Deserializer(ser.output()))
+        self.assertEqual([i for i, _ in ms.signatures], [i for i, _ in out.signatures])
+        # Re-serializing the deserialized form must produce the original bytes.
+        ser2 = Serializer()
+        out.serialize(ser2)
+        self.assertEqual(ser.output(), ser2.output())
+        self.assertNotEqual(ms, "x")
+        with self.assertRaises(ValueError):
+            asymmetric_crypto_wrapper.MultiSignature([(99, sig)])
+
+
+class IndexerClientTests(unittest.TestCase):
+    def test_query_handles_errors_field(self):
+        client = IndexerClient("http://mock.invalid/graphql")
+
+        async def fake_query(query, variables):
+            return {"errors": [{"message": "boom"}]}
+
+        client.client.execute_async = fake_query  # type: ignore[assignment]
+        with self.assertRaises(IndexerError):
+            _run(client.query("{x}", {}))
+
+    def test_query_wraps_transport_error(self):
+        client = IndexerClient("http://mock.invalid/graphql", bearer_token="t")
+
+        async def fake_query(query, variables):
+            raise RuntimeError("rate limit")
+
+        client.client.execute_async = fake_query  # type: ignore[assignment]
+        with self.assertRaises(IndexerError) as ctx:
+            _run(client.query("{x}", {}))
+        self.assertIn("rate limit", str(ctx.exception))
+
+    def test_bearer_token_is_set(self):
+        client = IndexerClient("http://mock.invalid/graphql", bearer_token="secret")
+        self.assertEqual(client.client.headers.get("Authorization"), "Bearer secret")
+
+
+class RestClientTests(unittest.TestCase):
+    def test_account_404_raises_account_not_found(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.url.path.endswith("/resources"):
+                return httpx.Response(404, text="missing")
+            return httpx.Response(200, json={})
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(AccountNotFound):
+            _run(client.account_resources(AccountAddress.from_str_relaxed(SAMPLE_ADDR)))
+        _run(client.close())
+
+    def test_account_resource_404_raises_resource_not_found(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="missing")
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(ResourceNotFound):
+            _run(
+                client.account_resource(
+                    AccountAddress.from_str_relaxed(SAMPLE_ADDR), "0x1::coin::CoinStore"
+                )
+            )
+        _run(client.close())
+
+    def test_account_sequence_number_zero_on_404(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="missing")
+
+        client = _build_rest_client(handler)
+        seq = _run(client.account_sequence_number(AccountAddress.from_str_relaxed(SAMPLE_ADDR)))
+        self.assertEqual(seq, 0)
+        _run(client.close())
+
+    def test_chain_id_caches(self):
+        calls = {"n": 0}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(200, json={"chain_id": 233})
+
+        client = _build_rest_client(handler)
+        self.assertEqual(_run(client.chain_id()), 233)
+        self.assertEqual(_run(client.chain_id()), 233)
+        self.assertEqual(calls["n"], 1)
+        _run(client.close())
+
+    def test_api_key_sets_authorization_header(self):
+        client = RestClient("http://mock.invalid", ClientConfig(api_key="abc", http2=False))
+        self.assertEqual(client.client.headers.get("Authorization"), "Bearer abc")
+        _run(client.close())
+
+    def test_account_balance_decodes_view_response(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            assert req.url.path.endswith("/view")
+            return httpx.Response(200, json=["12345"])
+
+        client = _build_rest_client(handler)
+        bal = _run(client.account_balance(AccountAddress.from_str_relaxed(SAMPLE_ADDR)))
+        self.assertEqual(bal, 12345)
+        _run(client.close())
+
+    def test_view_returns_raw_bytes(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=["0x1"])
+
+        client = _build_rest_client(handler)
+        result = _run(client.view("0x1::coin::balance", [], [SAMPLE_ADDR]))
+        self.assertIn(b"0x1", result)
+        _run(client.close())
+
+    def test_view_error_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="internal")
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(ApiError):
+            _run(client.view("0x1::x::y", [], []))
+        _run(client.close())
+
+    def test_aggregator_value_traverses_resource(self):
+        resource = {
+            "data": {
+                "supply": {
+                    "vec": [
+                        {
+                            "aggregator": {
+                                "vec": [{"handle": "0x1", "key": "0x2"}],
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if "/resource/" in req.url.path:
+                return httpx.Response(200, json=resource)
+            if "/tables/" in req.url.path:
+                return httpx.Response(200, json="42")
+            return httpx.Response(404)
+
+        client = _build_rest_client(handler)
+        v = _run(
+            client.aggregator_value(
+                AccountAddress.from_str_relaxed(SAMPLE_ADDR),
+                "0x1::coin::CoinInfo",
+                ["supply"],
+            )
+        )
+        self.assertEqual(v, 42)
+        _run(client.close())
+
+    def test_aggregator_value_missing_path_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": {"supply": {"vec": []}}})
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(ApiError):
+            _run(
+                client.aggregator_value(
+                    AccountAddress.from_str_relaxed(SAMPLE_ADDR),
+                    "0x1::coin::CoinInfo",
+                    ["supply"],
+                )
+            )
+        _run(client.close())
+
+    def test_wait_for_transaction_timeout(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            # Always pending → triggers timeout.
+            return httpx.Response(200, json={"type": "pending_transaction"})
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(TransactionTimeout):
+            _run(client.wait_for_transaction("0xabc"))
+        _run(client.close())
+
+    def test_wait_for_transaction_failure(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"type": "user_transaction", "success": False})
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(TransactionFailed):
+            _run(client.wait_for_transaction("0xabc"))
+        _run(client.close())
+
+    def test_transaction_pending_404_returns_true(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="missing")
+
+        client = _build_rest_client(handler)
+        self.assertTrue(_run(client.transaction_pending("0xabc")))
+        _run(client.close())
+
+    def test_blocks_and_events_round_trip_errors(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="bad")
+
+        client = _build_rest_client(handler)
+        for coro in (
+            client.blocks_by_height(0),
+            client.blocks_by_version(0),
+            client.event_by_creation_number(AccountAddress.from_str_relaxed(SAMPLE_ADDR), 0),
+            client.events_by_event_handle(
+                AccountAddress.from_str_relaxed(SAMPLE_ADDR), "0x1::x::Y", "f"
+            ),
+            client.transactions(),
+            client.transactions_by_account(AccountAddress.from_str_relaxed(SAMPLE_ADDR)),
+            client.transaction_by_hash("0x1"),
+            client.transaction_by_version(0),
+            client.account_module(AccountAddress.from_str_relaxed(SAMPLE_ADDR), "coin"),
+        ):
+            with self.assertRaises(ApiError):
+                _run(coro)
+        _run(client.close())
+
+
+class FaucetClientTests(unittest.TestCase):
+    def _client(self, handler):
+        rest = _build_rest_client(handler, base_url="http://node.invalid/v1")
+        return FaucetClient("http://faucet.invalid", rest, auth_token="tok")
+
+    def test_fund_account_success(self):
+        seen_paths = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seen_paths.append(req.url.path)
+            if req.url.path.endswith("/fund"):
+                return httpx.Response(200, json={"txn_hashes": ["0xabc"]})
+            # wait_for_transaction calls
+            return httpx.Response(200, json={"type": "user_transaction", "success": True})
+
+        c = self._client(handler)
+        h = _run(c.fund_account(AccountAddress.from_str_relaxed(SAMPLE_ADDR), 100))
+        self.assertEqual(h, "0xabc")
+        self.assertTrue(any(p.endswith("/fund") for p in seen_paths))
+        _run(c.close())
+
+    def test_fund_account_failure_raises(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(429, text="rate limited")
+
+        c = self._client(handler)
+        with self.assertRaises(ApiError):
+            _run(c.fund_account(AccountAddress.from_str_relaxed(SAMPLE_ADDR), 100))
+        _run(c.close())
+
+    def test_healthy_returns_false_on_error(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="bad")
+
+        c = self._client(handler)
+        self.assertFalse(_run(c.healthy()))
+        _run(c.close())
+
+    def test_healthy_returns_true_on_ok(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, text="tap:ok")
+
+        c = self._client(handler)
+        self.assertTrue(_run(c.healthy()))
+        _run(c.close())
+
+
+class PackagePublisherTests(unittest.TestCase):
+    def test_create_chunks_splits_input(self):
+        data = b"x" * (MAX_TRANSACTION_SIZE * 2 + 5)
+        chunks = PackagePublisher.create_chunks(data)
+        self.assertEqual(len(chunks), 3)
+        self.assertEqual(b"".join(chunks), data)
+        self.assertEqual(len(chunks[0]), MAX_TRANSACTION_SIZE)
+
+    def test_is_large_package(self):
+        small = b"x" * 100
+        self.assertFalse(PackagePublisher.is_large_package(small, [small]))
+        big = b"x" * (MAX_TRANSACTION_SIZE + 1)
+        self.assertTrue(PackagePublisher.is_large_package(big, []))
+
+    def test_create_object_deployment_address_is_deterministic(self):
+        addr = AccountAddress.from_str_relaxed("0x1")
+        a = PackagePublisher.create_object_deployment_address(addr, 1)
+        b = PackagePublisher.create_object_deployment_address(addr, 1)
+        c = PackagePublisher.create_object_deployment_address(addr, 2)
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
+
+    def test_large_package_payload_is_an_entry_function(self):
+        addr = AccountAddress.from_str_relaxed("0x1")
+        payload = PackagePublisher.create_large_package_publishing_payload(
+            addr, b"meta", [0, 1], [b"m0", b"m1"], True
+        )
+        self.assertIsInstance(payload, TransactionPayload)
+        self.assertEqual(payload.variant, TransactionPayload.SCRIPT_FUNCTION)
+        self.assertIsInstance(payload.value, EntryFunction)
+        self.assertEqual(payload.value.function, "stage_code")
+
+    def test_publish_mode_enum(self):
+        self.assertEqual(PublishMode.ACCOUNT_DEPLOY.value, "ACCOUNT_DEPLOY")
+        self.assertEqual(PublishMode.OBJECT_DEPLOY.value, "OBJECT_DEPLOY")
+        self.assertEqual(PublishMode.OBJECT_UPGRADE.value, "OBJECT_UPGRADE")
+
+    def test_publish_package_in_path_requires_code_object_for_upgrade(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "build", "demo", "bytecode_modules"))
+            with open(os.path.join(tmp, "Move.toml"), "wb") as f:
+                f.write(b'[package]\nname = "demo"\n')
+            with open(os.path.join(tmp, "build", "demo", "package-metadata.bcs"), "wb") as f:
+                f.write(b"meta")
+            with open(os.path.join(tmp, "build", "demo", "bytecode_modules", "m.mv"), "wb") as f:
+                f.write(b"\xfe\xfe")
+
+            client = mock.Mock(spec=RestClient)
+            publisher = PackagePublisher(client)
+            with self.assertRaises(ValueError):
+                _run(
+                    publisher.publish_package_in_path(
+                        Account.generate(),
+                        tmp,
+                        publish_mode=PublishMode.OBJECT_UPGRADE,
+                    )
+                )
+
+    def test_object_code_deployment_domain_separator_constant(self):
+        # This must never change; on-chain object addresses are derived from it.
+        self.assertEqual(
+            OBJECT_CODE_DEPLOYMENT_DOMAIN_SEPARATOR,
+            b"aptos_framework::object_code_deployment",
+        )
+
+
+class CliTests(unittest.TestCase):
+    def test_key_value_parses_pair(self):
+        name, addr = key_value("foo=0x1")
+        self.assertEqual(name, "foo")
+        self.assertEqual(addr, AccountAddress.from_str("0x1"))
+
+    def test_key_value_invalid_raises(self):
+        with self.assertRaises(ValueError):
+            key_value("no-equal-sign")
+
+
+class AptosTokenClientPropertyTests(unittest.TestCase):
+    def test_property_round_trip_all_types(self):
+        addr = AccountAddress.from_str_relaxed("0x1")
+        cases = [
+            (Property.bool("a", True), Property.BOOL),
+            (Property.u8("a", 1), Property.U8),
+            (Property.u16("a", 1), Property.U16),
+            (Property.u32("a", 1), Property.U32),
+            (Property.u64("a", 1), Property.U64),
+            (Property.u128("a", 1), Property.U128),
+            (Property.u256("a", 1), Property.U256),
+            (Property("a", "address", addr), Property.ADDRESS),
+            (Property.string("a", "hello"), Property.STRING),
+            (Property.bytes("a", b"\x01"), Property.BYTE_VECTOR),
+        ]
+        for prop, type_id in cases:
+            data = prop.serialize_value()
+            parsed = Property.parse(prop.name, type_id, data)
+            self.assertEqual(parsed.value, prop.value)
+            self.assertEqual(parsed.property_type, prop.property_type)
+            args = prop.to_transaction_arguments()
+            self.assertEqual(len(args), 3)
+            for arg in args:
+                self.assertIsInstance(arg, TransactionArgument)
+
+    def test_property_invalid_type_raises(self):
+        with self.assertRaises(InvalidPropertyType):
+            Property("a", "weird", 1).serialize_value()
+        with self.assertRaises(InvalidPropertyType):
+            Property.parse("a", 99, b"")
+
+    def test_property_map_to_tuple(self):
+        pmap = PropertyMap([Property.u64("a", 1), Property.string("b", "x")])
+        names, types, values = pmap.to_tuple()
+        self.assertEqual(names, ["a", "b"])
+        self.assertEqual(types, ["u64", "0x1::string::String"])
+        self.assertEqual(len(values), 2)
+        self.assertIn("Property", str(pmap))
+
+    def test_property_map_parse(self):
+        # Build the on-chain shape: each value has hex-encoded BCS bytes.
+        prop_bytes = "0x" + Property.u64("x", 7).serialize_value().hex()
+        resource = {
+            "inner": {"data": [{"key": "x", "value": {"type": Property.U64, "value": prop_bytes}}]}
+        }
+        pm = PropertyMap.parse(resource)
+        self.assertEqual(pm.properties[0].name, "x")
+        self.assertEqual(pm.properties[0].value, 7)
+
+
+class AptosTokenClientReadObjectTests(unittest.TestCase):
+    def test_read_object_dispatches_resources(self):
+        addr = AccountAddress.from_str_relaxed("0x1")
+        resources = [
+            {
+                "type": Object.struct_tag,
+                "data": {"allow_ungated_transfer": True, "owner": str(addr)},
+            },
+            {
+                "type": Royalty.struct_tag,
+                "data": {"numerator": "1", "denominator": "10", "payee_address": str(addr)},
+            },
+            {
+                "type": Collection.struct_tag,
+                "data": {
+                    "creator": str(addr),
+                    "description": "d",
+                    "name": "n",
+                    "uri": "u",
+                },
+            },
+            {
+                "type": Token.struct_tag,
+                "data": {
+                    "collection": {"inner": str(addr)},
+                    "index": "5",
+                    "description": "d",
+                    "name": "n",
+                    "uri": "u",
+                },
+            },
+            {"type": "0x1::other::Thing", "data": {}},
+        ]
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=resources)
+
+        client = _build_rest_client(handler)
+        token_client = AptosTokenClient(client)
+        result = _run(token_client.read_object(addr))
+        self.assertIsInstance(result, ReadObject)
+        self.assertEqual(len(result.resources), 4)
+        self.assertIn("ReadObject", str(result))
+        # Each parsed type should expose its struct_tag.
+        for cls in (Object, Royalty, Collection, Token):
+            self.assertIn(cls, result.resources)
+        _run(client.close())
+
+    def test_collection_and_token_string(self):
+        addr = AccountAddress.from_str_relaxed("0x1")
+        c = Collection(addr, "d", "n", "u")
+        self.assertIn("creator:", str(c))
+        t = Token(addr, 1, "d", "n", "u")
+        self.assertIn("collection:", str(t))
+        o = Object(True, addr)
+        self.assertIn("owner:", str(o))
+        r = Royalty(1, 10, addr)
+        self.assertIn("payee_address:", str(r))
+
+
+class AptosTokenV1ClientTests(unittest.TestCase):
+    def _make(self, handler):
+        client = _build_rest_client(handler)
+        return AptosTokenV1Client(client), client
+
+    def test_get_token_balance_uses_table(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            if "/resource/" in req.url.path:
+                return httpx.Response(200, json={"data": {"tokens": {"handle": "0xdead"}}})
+            if "/tables/" in req.url.path:
+                return httpx.Response(200, json={"amount": "9"})
+            return httpx.Response(404)
+
+        token_client, client = self._make(handler)
+        addr = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+        bal = _run(token_client.get_token_balance(addr, addr, "C", "T", "0"))
+        self.assertEqual(bal, "9")
+        _run(client.close())
+
+    def test_get_collection_returns_data(self):
+        payload = {"name": "C"}
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if "/resource/" in req.url.path:
+                return httpx.Response(200, json={"data": {"collection_data": {"handle": "0xbeef"}}})
+            if "/tables/" in req.url.path:
+                return httpx.Response(200, json=payload)
+            return httpx.Response(404)
+
+        token_client, client = self._make(handler)
+        addr = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+        result = _run(token_client.get_collection(addr, "C"))
+        self.assertEqual(result, payload)
+        _run(client.close())
+
+
+class SignedTransactionTests(unittest.TestCase):
+    def test_str_includes_components(self):
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_key(sk.public_key())
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(sender, Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        raw = RawTransaction(sender, 0, payload, 1000, 1, 2_000_000_000, 4)
+        auth = raw.sign(sk)
+        signed = SignedTransaction(raw, auth)
+        self.assertIn("Transaction", str(signed))
+        self.assertEqual(signed, SignedTransaction(raw, auth))
+        self.assertNotEqual(signed, "x")
+
+    def test_simulated_signature_is_zero(self):
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_key(sk.public_key())
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(sender, Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        raw = RawTransaction(sender, 0, payload, 1000, 1, 2_000_000_000, 4)
+        auth = raw.sign_simulated(sk.public_key())
+        signed = SignedTransaction(raw, auth)
+        # Simulated signature is all zeros; verify() must therefore fail.
+        self.assertFalse(signed.verify())
+
+
+class AccountAuthenticatorTests(unittest.TestCase):
+    def test_authenticator_invalid_type_raises(self):
+        with self.assertRaises(InvalidTypeError):
+            Authenticator(object())
+
+    def test_authenticator_round_trip(self):
+        sk = ed25519.PrivateKey.random()
+        ed_auth = Ed25519Authenticator(sk.public_key(), sk.sign(b"x"))
+        outer = Authenticator(ed_auth)
+        ser = Serializer()
+        outer.serialize(ser)
+        out = Authenticator.deserialize(Deserializer(ser.output()))
+        self.assertEqual(outer, out)
+        self.assertIn("PublicKey", str(outer))
+
+    def test_invalid_authenticator_variant_in_stream(self):
+        ser = Serializer()
+        ser.uleb128(99)
+        with self.assertRaises(InvalidTypeError):
+            Authenticator.deserialize(Deserializer(ser.output()))
+
+    def test_multi_agent_secondary_addresses(self):
+        sk = ed25519.PrivateKey.random()
+        addr = AccountAddress.from_key(sk.public_key())
+        ed_auth = Ed25519Authenticator(sk.public_key(), sk.sign(b"x"))
+        from .authenticator import AccountAuthenticator
+
+        ma = MultiAgentAuthenticator(
+            AccountAuthenticator(ed_auth),
+            [(addr, AccountAuthenticator(ed_auth))],
+        )
+        self.assertEqual(ma.secondary_addresses(), [addr])
+
+
+class AccountStoreLoadTests(unittest.TestCase):
+    def test_account_store_then_load_round_trip(self):
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as f:
+            path = f.name
+        try:
+            a = Account.generate()
+            a.store(path)
+            with open(path) as fh:
+                data = json.load(fh)
+            self.assertIn("account_address", data)
+            b = Account.load(path)
+            self.assertEqual(a, b)
+        finally:
+            os.unlink(path)
+
+    def test_account_eq_returns_not_implemented(self):
+        a = Account.generate()
+        self.assertNotEqual(a, "x")
+
+    def test_secp256k1_account_address_derives(self):
+        a = Account.generate_secp256k1_ecdsa()
+        wrapped = asymmetric_crypto_wrapper.PublicKey(a.public_key())
+        self.assertEqual(a.address(), AccountAddress.from_key(wrapped))
+
+
+class RestClientTransactionHelpersTests(unittest.TestCase):
+    """Exercise the transaction-submission helpers using a mocked transport."""
+
+    def _client(self, handler):
+        return _build_rest_client(handler)
+
+    def test_submit_bcs_transaction_returns_hash(self):
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_key(sk.public_key())
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(sender, Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        raw = RawTransaction(sender, 0, payload, 1000, 1, 2_000_000_000, 4)
+        signed = SignedTransaction(raw, raw.sign(sk))
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(202, json={"hash": "0xface"})
+
+        client = self._client(handler)
+        h = _run(client.submit_bcs_transaction(signed))
+        self.assertEqual(h, "0xface")
+        _run(client.close())
+
+    def test_submit_bcs_transaction_error(self):
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_key(sk.public_key())
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(sender, Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        raw = RawTransaction(sender, 0, payload, 1000, 1, 2_000_000_000, 4)
+        signed = SignedTransaction(raw, raw.sign(sk))
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="bad")
+
+        client = self._client(handler)
+        with self.assertRaises(ApiError):
+            _run(client.submit_bcs_transaction(signed))
+        _run(client.close())
+
+    def test_simulate_bcs_transaction(self):
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_key(sk.public_key())
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(sender, Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        raw = RawTransaction(sender, 0, payload, 1000, 1, 2_000_000_000, 4)
+        signed = SignedTransaction(raw, raw.sign(sk))
+
+        params_seen: list[dict] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            params_seen.append(dict(req.url.params))
+            return httpx.Response(200, json=[{"success": True}])
+
+        client = self._client(handler)
+        out = _run(client.simulate_bcs_transaction(signed, estimate_gas_usage=True))
+        self.assertEqual(out, [{"success": True}])
+        self.assertIn("estimate_gas_unit_price", params_seen[0])
+        # Test simulate_transaction (uses sign_simulated)
+        out2 = _run(client.simulate_transaction(raw, Account(sender, sk)))
+        self.assertEqual(out2[0]["success"], True)
+        _run(client.close())
+
+    def test_create_bcs_signed_transaction_uses_address_only(self):
+        seq_calls: list[str] = []
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            seq_calls.append(req.url.path)
+            if "/accounts/" in req.url.path and req.url.path.endswith(SAMPLE_ADDR):
+                return httpx.Response(200, json={"sequence_number": "5"})
+            return httpx.Response(200, json={"chain_id": 4})
+
+        client = self._client(handler)
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+        # Pre-cache chain id to avoid extra RPCs.
+        client._chain_id = 4
+        raw = _run(
+            client.create_bcs_transaction(
+                sender,
+                TransactionPayload(
+                    EntryFunction.natural(
+                        "0x1::aptos_account",
+                        "transfer",
+                        [],
+                        [
+                            TransactionArgument(sender, Serializer.struct),
+                            TransactionArgument(1, Serializer.u64),
+                        ],
+                    )
+                ),
+            )
+        )
+        self.assertEqual(raw.sequence_number, 5)
+        self.assertEqual(raw.chain_id, 4)
+        # Account-form sender path (covers `if isinstance(sender, Account)`).
+        signed = _run(
+            client.create_bcs_signed_transaction(
+                Account(sender, sk),
+                TransactionPayload(
+                    EntryFunction.natural(
+                        "0x1::aptos_account",
+                        "transfer",
+                        [],
+                        [
+                            TransactionArgument(sender, Serializer.struct),
+                            TransactionArgument(2, Serializer.u64),
+                        ],
+                    )
+                ),
+                sequence_number=11,
+            )
+        )
+        self.assertEqual(signed.transaction.sequence_number, 11)
+        _run(client.close())
+
+    def test_transfer_helpers_submit_signed_transaction(self):
+        sk = ed25519.PrivateKey.random()
+        sender = Account(AccountAddress.from_key(sk.public_key()), sk)
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.url.path.endswith("/transactions") and req.method == "POST":
+                return httpx.Response(202, json={"hash": "0x1234"})
+            if "/accounts/" in req.url.path:
+                return httpx.Response(200, json={"sequence_number": "0"})
+            return httpx.Response(200, json={"chain_id": 4})
+
+        client = self._client(handler)
+        client._chain_id = 4
+        recipient = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+        h = _run(client.bcs_transfer(sender, recipient, 100))
+        self.assertEqual(h, "0x1234")
+        h2 = _run(client.transfer_coins(sender, recipient, "0x1::aptos_coin::AptosCoin", 100))
+        self.assertEqual(h2, "0x1234")
+        h3 = _run(client.transfer_object(sender, recipient, recipient))
+        self.assertEqual(h3, "0x1234")
+        _run(client.close())
+
+
+class TokenV1ClientHelpersTests(unittest.TestCase):
+    """Exercise AptosTokenV1Client helpers via a mocked REST client."""
+
+    def setUp(self) -> None:
+        self.sk = ed25519.PrivateKey.random()
+        self.account = Account(AccountAddress.from_key(self.sk.public_key()), self.sk)
+        self.recipient = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+
+    def _client(self, handler):
+        client = _build_rest_client(handler)
+        client._chain_id = 4
+        return AptosTokenV1Client(client), client
+
+    def _post_returns_hash(self, req: httpx.Request) -> httpx.Response:
+        if req.method == "POST" and req.url.path.endswith("/transactions"):
+            return httpx.Response(202, json={"hash": "0xtoken"})
+        if "/accounts/" in req.url.path:
+            return httpx.Response(200, json={"sequence_number": "0"})
+        return httpx.Response(200, json={"chain_id": 4})
+
+    def test_create_collection(self):
+        tc, c = self._client(self._post_returns_hash)
+        h = _run(tc.create_collection(self.account, "n", "d", "u"))
+        self.assertEqual(h, "0xtoken")
+        _run(c.close())
+
+    def test_create_token(self):
+        tc, c = self._client(self._post_returns_hash)
+        h = _run(tc.create_token(self.account, "C", "T", "d", 1, "u", 0))
+        self.assertEqual(h, "0xtoken")
+        _run(c.close())
+
+    def test_offer_and_claim_token(self):
+        tc, c = self._client(self._post_returns_hash)
+        h = _run(tc.offer_token(self.account, self.recipient, self.recipient, "C", "T", 0, 1))
+        self.assertEqual(h, "0xtoken")
+        h2 = _run(tc.claim_token(self.account, self.recipient, self.recipient, "C", "T", 0))
+        self.assertEqual(h2, "0xtoken")
+        _run(c.close())
+
+    def test_direct_transfer_token(self):
+        receiver_sk = ed25519.PrivateKey.random()
+        receiver = Account(AccountAddress.from_key(receiver_sk.public_key()), receiver_sk)
+        tc, c = self._client(self._post_returns_hash)
+        h = _run(tc.direct_transfer_token(self.account, receiver, self.recipient, "C", "T", 0, 1))
+        self.assertEqual(h, "0xtoken")
+        _run(c.close())
+
+    def test_transfer_object(self):
+        tc, c = self._client(self._post_returns_hash)
+        h = _run(tc.transfer_object(self.account, self.recipient, self.recipient))
+        self.assertEqual(h, "0xtoken")
+        _run(c.close())
+
+    def test_get_token_returns_zero_amount_on_404(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            if "/resource/" in req.url.path:
+                return httpx.Response(200, json={"data": {"tokens": {"handle": "0xh"}}})
+            return httpx.Response(404)
+
+        tc, c = self._client(handler)
+        info = _run(tc.get_token(self.recipient, self.recipient, "C", "T", 0))
+        self.assertEqual(info["amount"], "0")
+        _run(c.close())
+
+    def test_get_token_data(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            if "/resource/" in req.url.path:
+                return httpx.Response(200, json={"data": {"token_data": {"handle": "0xh"}}})
+            return httpx.Response(200, json={"name": "T"})
+
+        tc, c = self._client(handler)
+        out = _run(tc.get_token_data(self.recipient, "C", "T", 0))
+        self.assertEqual(out, {"name": "T"})
+        _run(c.close())
+
+
+class TokenClientPayloadTests(unittest.TestCase):
+    """Exercise AptosTokenClient v2 payload constructors and submit helpers."""
+
+    def setUp(self) -> None:
+        self.sk = ed25519.PrivateKey.random()
+        self.account = Account(AccountAddress.from_key(self.sk.public_key()), self.sk)
+        self.addr = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+
+    def _client(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "POST" and req.url.path.endswith("/transactions"):
+                return httpx.Response(202, json={"hash": "0xtok2"})
+            if "/accounts/" in req.url.path:
+                return httpx.Response(200, json={"sequence_number": "0"})
+            return httpx.Response(200, json={"chain_id": 4})
+
+        rest = _build_rest_client(handler)
+        rest._chain_id = 4
+        return AptosTokenClient(rest), rest
+
+    def test_create_collection_payload_round_trip(self):
+        payload = AptosTokenClient.create_collection_payload(
+            "desc", 100, "n", "u", *([True] * 9), 5, 100
+        )
+        self.assertIsInstance(payload, TransactionPayload)
+        self.assertEqual(payload.value.function, "create_collection")
+
+    def test_create_collection_submits(self):
+        tc, c = self._client()
+        h = _run(
+            tc.create_collection(
+                self.account,
+                "desc",
+                100,
+                "n",
+                "u",
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                5,
+                100,
+            )
+        )
+        self.assertEqual(h, "0xtok2")
+        _run(c.close())
+
+    def test_mint_token(self):
+        tc, c = self._client()
+        h = _run(
+            tc.mint_token(self.account, "C", "d", "T", "u", PropertyMap([Property.u64("a", 1)]))
+        )
+        self.assertEqual(h, "0xtok2")
+        _run(c.close())
+
+    def test_burn_token(self):
+        tc, c = self._client()
+        h = _run(tc.burn_token(self.account, self.addr))
+        self.assertEqual(h, "0xtok2")
+        _run(c.close())
+
+    def test_freeze_unfreeze_transfer_token(self):
+        tc, c = self._client()
+        for fn in (
+            tc.freeze_token,
+            tc.unfreeze_token,
+        ):
+            h = _run(fn(self.account, self.addr))
+            self.assertEqual(h, "0xtok2")
+        h = _run(tc.transfer_token(self.account, self.addr, self.addr))
+        self.assertEqual(h, "0xtok2")
+        _run(c.close())
+
+    def test_property_management(self):
+        tc, c = self._client()
+        prop = Property.u64("k", 5)
+        for coro in (
+            tc.add_token_property(self.account, self.addr, prop),
+            tc.update_token_property(self.account, self.addr, prop),
+            tc.remove_token_property(self.account, self.addr, "k"),
+        ):
+            self.assertEqual(_run(coro), "0xtok2")
+        _run(c.close())
+
+
+class PackagePublisherSubmitTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sk = ed25519.PrivateKey.random()
+        self.account = Account(AccountAddress.from_key(self.sk.public_key()), self.sk)
+
+    def _client(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "POST" and req.url.path.endswith("/transactions"):
+                return httpx.Response(202, json={"hash": "0xpub"})
+            if "/accounts/" in req.url.path and req.url.path.endswith(
+                "/transactions/by_hash/0xpub"
+            ):
+                return httpx.Response(200, json={"type": "user_transaction", "success": True})
+            if "/transactions/by_hash/" in req.url.path:
+                return httpx.Response(200, json={"type": "user_transaction", "success": True})
+            if "/accounts/" in req.url.path:
+                return httpx.Response(200, json={"sequence_number": "0"})
+            return httpx.Response(200, json={"chain_id": 4})
+
+        rest = _build_rest_client(handler)
+        rest._chain_id = 4
+        return PackagePublisher(rest), rest
+
+    def test_publish_package_submits(self):
+        pub, c = self._client()
+        h = _run(pub.publish_package(self.account, b"meta", [b"m"]))
+        self.assertEqual(h, "0xpub")
+        _run(c.close())
+
+    def test_publish_package_to_object(self):
+        pub, c = self._client()
+        h = _run(pub.publish_package_to_object(self.account, b"meta", [b"m"]))
+        self.assertEqual(h, "0xpub")
+        _run(c.close())
+
+    def test_upgrade_package_object(self):
+        pub, c = self._client()
+        addr = AccountAddress.from_str_relaxed(SAMPLE_ADDR)
+        h = _run(pub.upgrade_package_object(self.account, b"meta", [b"m"], addr))
+        self.assertEqual(h, "0xpub")
+        _run(c.close())
+
+    def test_publish_package_in_path_account_deploy(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.makedirs(os.path.join(tmp, "build", "demo", "bytecode_modules"))
+            with open(os.path.join(tmp, "Move.toml"), "wb") as f:
+                f.write(b'[package]\nname = "demo"\n')
+            with open(os.path.join(tmp, "build", "demo", "package-metadata.bcs"), "wb") as f:
+                f.write(b"meta")
+            with open(os.path.join(tmp, "build", "demo", "bytecode_modules", "m.mv"), "wb") as f:
+                f.write(b"\xfe\xfe")
+            pub, c = self._client()
+            hashes = _run(pub.publish_package_in_path(self.account, tmp))
+            self.assertEqual(hashes, ["0xpub"])
+            _run(c.close())
+
+    def test_chunked_package_publish(self):
+        pub, c = self._client()
+        big_meta = b"\x00" * (MAX_TRANSACTION_SIZE + 100)
+        big_module = b"\xff" * (MAX_TRANSACTION_SIZE + 100)
+        hashes = _run(pub.chunked_package_publish(self.account, big_meta, [big_module]))
+        # Multiple stage_code transactions plus the final publish.
+        self.assertGreaterEqual(len(hashes), 2)
+        self.assertEqual(hashes[0], "0xpub")
+        _run(c.close())
+
+
+class CliWrapperTests(unittest.TestCase):
+    def test_prepare_named_addresses(self):
+        addr = AccountAddress.from_str("0x1")
+        from .aptos_cli_wrapper import AptosCLIWrapper
+
+        self.assertEqual(AptosCLIWrapper.prepare_named_addresses({}), [])
+        out = AptosCLIWrapper.prepare_named_addresses({"a": addr, "b": addr})
+        self.assertEqual(out[0], "--named-addresses")
+        # The first pair gets a comma, the last does not.
+        self.assertTrue(out[1].endswith(","))
+        self.assertFalse(out[2].endswith(","))
+
+    def test_does_cli_exist_returns_bool(self):
+        from .aptos_cli_wrapper import AptosCLIWrapper
+
+        self.assertIsInstance(AptosCLIWrapper.does_cli_exist(), bool)
+
+    def test_assert_cli_exists_raises_when_absent(self):
+        from .aptos_cli_wrapper import AptosCLIWrapper, MissingCLIError
+
+        with mock.patch.object(AptosCLIWrapper, "does_cli_exist", return_value=False):
+            with self.assertRaises(MissingCLIError):
+                AptosCLIWrapper.assert_cli_exists()
+
+    def test_compile_package_raises_on_failure(self):
+        from .aptos_cli_wrapper import AptosCLIWrapper, CLIError
+
+        with (
+            mock.patch.object(AptosCLIWrapper, "assert_cli_exists"),
+            mock.patch("aptos_sdk.aptos_cli_wrapper.subprocess.run") as run_mock,
+        ):
+            run_mock.return_value = mock.Mock(returncode=1, stdout=b"", stderr=b"oops")
+            with self.assertRaises(CLIError):
+                AptosCLIWrapper.compile_package("/nonexistent", {})
+
+    def test_test_package_success(self):
+        from .aptos_cli_wrapper import AptosCLIWrapper
+
+        with (
+            mock.patch.object(AptosCLIWrapper, "assert_cli_exists"),
+            mock.patch("aptos_sdk.aptos_cli_wrapper.subprocess.run") as run_mock,
+        ):
+            run_mock.return_value = mock.Mock(returncode=0)
+            AptosCLIWrapper.test_package("/x", {})
+            run_mock.assert_called_once()
+
+
+class CliMainTests(unittest.TestCase):
+    """Cover the argparse main() entrypoint without invoking the actual CLI."""
+
+    def test_main_publish_package_invokes_publisher(self):
+        from . import cli as cli_mod
+
+        with tempfile.NamedTemporaryFile("w", suffix=".key", delete=False) as f:
+            sk = ed25519.PrivateKey.random()
+            f.write(str(sk))
+            key_path = f.name
+        try:
+            with (
+                mock.patch.object(cli_mod.AptosCLIWrapper, "does_cli_exist", return_value=True),
+                mock.patch.object(cli_mod.AptosCLIWrapper, "compile_package"),
+                mock.patch.object(
+                    cli_mod.PackagePublisher, "publish_package_in_path", new=mock.AsyncMock()
+                ) as pub_mock,
+            ):
+                _run(
+                    cli_mod.main(
+                        [
+                            "publish-package",
+                            "--account",
+                            "0x1",
+                            "--package-dir",
+                            "/tmp/x",
+                            "--rest-api",
+                            "http://node.invalid/v1",
+                            "--private-key-path",
+                            key_path,
+                            "--named-address",
+                            "foo=0x1",
+                        ]
+                    )
+                )
+                pub_mock.assert_awaited()
+        finally:
+            os.unlink(key_path)
+
+    def test_main_errors_when_cli_missing(self):
+        from . import cli as cli_mod
+
+        with mock.patch.object(cli_mod.AptosCLIWrapper, "does_cli_exist", return_value=False):
+            with self.assertRaises(SystemExit):
+                _run(
+                    cli_mod.main(
+                        [
+                            "publish-package",
+                            "--account",
+                            "0x1",
+                            "--package-dir",
+                            "/tmp/x",
+                            "--rest-api",
+                            "http://node.invalid/v1",
+                        ]
+                    )
+                )
+
+    def test_main_requires_package_dir(self):
+        from . import cli as cli_mod
+
+        with self.assertRaises(SystemExit):
+            _run(cli_mod.main(["publish-package", "--account", "0x1"]))
+
+
+class AsyncClientExtraEndpointsTests(unittest.TestCase):
+    """Cover endpoints that weren't yet exercised: account_module, blocks, events, etc."""
+
+    def test_account_module_success(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"abi": {"name": "coin"}})
+
+        client = _build_rest_client(handler)
+        out = _run(client.account_module(AccountAddress.from_str_relaxed(SAMPLE_ADDR), "coin"))
+        self.assertEqual(out["abi"]["name"], "coin")
+        _run(client.close())
+
+    def test_account_modules_success(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[{"abi": {"name": "coin"}}])
+
+        client = _build_rest_client(handler)
+        out = _run(client.account_modules(AccountAddress.from_str_relaxed(SAMPLE_ADDR)))
+        self.assertEqual(len(out), 1)
+        _run(client.close())
+
+    def test_blocks_and_events_success(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"x": 1})
+
+        client = _build_rest_client(handler)
+        self.assertEqual(_run(client.blocks_by_height(0)), {"x": 1})
+        self.assertEqual(_run(client.blocks_by_version(0, with_transactions=True)), {"x": 1})
+        _run(client.close())
+
+    def test_get_table_item_success(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"v": "ok"})
+
+        client = _build_rest_client(handler)
+        out = _run(client.get_table_item("0xh", "address", "u128", "0x1"))
+        self.assertEqual(out["v"], "ok")
+        _run(client.close())
+
+    def test_get_table_item_error(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(500, text="bad")
+
+        client = _build_rest_client(handler)
+        with self.assertRaises(ApiError):
+            _run(client.get_table_item("0xh", "address", "u128", "0x1"))
+        _run(client.close())
+
+    def test_account_transaction_sequence_number_status(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[{"type": "user_transaction"}])
+
+        client = _build_rest_client(handler)
+        ok = _run(
+            client.account_transaction_sequence_number_status(
+                AccountAddress.from_str_relaxed(SAMPLE_ADDR), 0
+            )
+        )
+        self.assertTrue(ok)
+        _run(client.close())
+
+    def test_current_timestamp(self):
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"ledger_timestamp": "1000000000"})
+
+        client = _build_rest_client(handler)
+        ts = _run(client.current_timestamp())
+        self.assertAlmostEqual(ts, 1000.0, places=2)
+        _run(client.close())
+
+    def test_create_multi_agent_bcs_transaction(self):
+        sk1 = ed25519.PrivateKey.random()
+        sk2 = ed25519.PrivateKey.random()
+        a1 = Account(AccountAddress.from_key(sk1.public_key()), sk1)
+        a2 = Account(AccountAddress.from_key(sk2.public_key()), sk2)
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"sequence_number": "0"})
+
+        client = _build_rest_client(handler)
+        client._chain_id = 4
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(a2.address(), Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        signed = _run(client.create_multi_agent_bcs_transaction(a1, [a2], payload))
+        self.assertIsInstance(signed, SignedTransaction)
+        self.assertTrue(signed.verify())
+        _run(client.close())
+
+    def test_submit_and_wait_for_bcs_transaction(self):
+        sk = ed25519.PrivateKey.random()
+        sender = AccountAddress.from_key(sk.public_key())
+        payload = TransactionPayload(
+            EntryFunction.natural(
+                "0x1::aptos_account",
+                "transfer",
+                [],
+                [
+                    TransactionArgument(sender, Serializer.struct),
+                    TransactionArgument(1, Serializer.u64),
+                ],
+            )
+        )
+        raw = RawTransaction(sender, 0, payload, 1000, 1, 2_000_000_000, 4)
+        signed = SignedTransaction(raw, raw.sign(sk))
+
+        def handler(req: httpx.Request) -> httpx.Response:
+            if req.method == "POST" and req.url.path.endswith("/transactions"):
+                return httpx.Response(202, json={"hash": "0xab"})
+            return httpx.Response(200, json={"type": "user_transaction", "success": True})
+
+        client = _build_rest_client(handler)
+        out = _run(client.submit_and_wait_for_bcs_transaction(signed))
+        self.assertTrue(out["success"])
+        _run(client.close())
+
+
+class FeePayerAuthenticatorTests(unittest.TestCase):
+    def test_fee_payer_authenticator_round_trip(self):
+        sk = ed25519.PrivateKey.random()
+        addr = AccountAddress.from_key(sk.public_key())
+        sig = sk.sign(b"x")
+        from .authenticator import (
+            AccountAuthenticator,
+            Ed25519Authenticator,
+        )
+
+        ed = Ed25519Authenticator(sk.public_key(), sig)
+        sender = AccountAuthenticator(ed)
+        fp = FeePayerAuthenticator(sender, [(addr, sender)], (addr, sender))
+        # fee_payer_address & secondary_addresses
+        self.assertEqual(fp.fee_payer_address(), addr)
+        self.assertEqual(fp.secondary_addresses(), [addr])
+
+        ser = Serializer()
+        fp.serialize(ser)
+        out = FeePayerAuthenticator.deserialize(Deserializer(ser.output()))
+        self.assertEqual(fp, out)
+        self.assertNotEqual(fp, "x")
+        # MultiAgent verify path
+        ma = MultiAgentAuthenticator(sender, [(addr, sender)])
+        ser = Serializer()
+        ma.serialize(ser)
+        out_ma = MultiAgentAuthenticator.deserialize(Deserializer(ser.output()))
+        self.assertEqual(ma.secondary_addresses(), out_ma.secondary_addresses())
+
+    def test_single_sender_authenticator_round_trip(self):
+        sk = ed25519.PrivateKey.random()
+        from .authenticator import AccountAuthenticator, Ed25519Authenticator
+
+        ed = Ed25519Authenticator(sk.public_key(), sk.sign(b"x"))
+        ss = SingleSenderAuthenticator(AccountAuthenticator(ed))
+        ser = Serializer()
+        ss.serialize(ser)
+        out = SingleSenderAuthenticator.deserialize(Deserializer(ser.output()))
+        self.assertEqual(ss, out)
+
+
+class MetadataAndErrorsTests(unittest.TestCase):
+    def test_metadata_header_value(self):
+        from .metadata import Metadata
+
+        v = Metadata.get_aptos_header_val()
+        self.assertIn("python", v.lower())
+
+    def test_api_error_attributes(self):
+        e = ApiError("nope", 503)
+        self.assertEqual(e.status_code, 503)
+        self.assertIn("nope", str(e))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/aptos_sdk/transaction_worker.py
+++ b/aptos_sdk/transaction_worker.py
@@ -181,7 +181,12 @@ class Test(unittest.IsolatedAsyncioTestCase):
         )
         submit_txn_patcher.start()
 
-        rest_client = RestClient("https://fullnode.devnet.aptoslabs.com/v1")
+        # Placeholder URL — every network method is patched, so no real
+        # HTTP request is ever issued.
+        rest_client = RestClient("http://localhost:65535")
+        # `RestClient.create_bcs_signed_transaction` would call `chain_id()`
+        # via `create_bcs_transaction`; pre-cache it so no network is touched.
+        rest_client._chain_id = 4
         txn_queue = TransactionQueue(rest_client)
         txn_worker = TransactionWorker(Account.generate(), rest_client, txn_queue.next)
         txn_worker.start()

--- a/aptos_sdk/transactions.py
+++ b/aptos_sdk/transactions.py
@@ -344,8 +344,8 @@ class ScriptArgument:
     value: Any
 
     def __init__(self, variant: int, value: Any):
-        if variant < 0 or variant > 5:
-            raise InvalidTypeError("Invalid variant")
+        if variant < 0 or variant > 8:
+            raise InvalidTypeError(f"Invalid ScriptArgument variant {variant}")
 
         self.variant = variant
         self.value = value

--- a/aptos_sdk/v2/api/general_api.py
+++ b/aptos_sdk/v2/api/general_api.py
@@ -89,11 +89,13 @@ class GeneralApi:
         """
         from ..bcs import Serializer
         from ..transactions.payload import ModuleId
-        from ..types.type_tag import StructTag, TypeTag
+        from ..types.type_tag import TypeTag
 
-        # Build the BCS payload for the view request
+        # Build the BCS payload for the view request. ``TypeTag.from_str``
+        # supports primitives (``u64``, ``bool``, ``address``…), ``vector<T>``,
+        # and structs — anything the on-chain ABI accepts.
         module_id = ModuleId.from_str(module)
-        parsed_ty_args = [TypeTag(StructTag.from_str(t)) for t in ty_args] if ty_args else []
+        parsed_ty_args = [TypeTag.from_str(t) for t in ty_args] if ty_args else []
 
         ser = Serializer()
         module_id.serialize(ser)

--- a/aptos_sdk/v2/bcs/serializer.py
+++ b/aptos_sdk/v2/bcs/serializer.py
@@ -154,7 +154,7 @@ class Serializer:
     ) -> None:
         self.uleb128(len(values))
         for value in values:
-            self.fixed_bytes(_encode(value, value_encoder))
+            value_encoder(self, value)
 
     def map(
         self,

--- a/aptos_sdk/v2/bcs/serializer.py
+++ b/aptos_sdk/v2/bcs/serializer.py
@@ -154,7 +154,7 @@ class Serializer:
     ) -> None:
         self.uleb128(len(values))
         for value in values:
-            value_encoder(self, value)
+            self.fixed_bytes(_encode(value, value_encoder))
 
     def map(
         self,
@@ -162,12 +162,14 @@ class Serializer:
         key_encoder: Callable[[Serializer, Any], None],
         value_encoder: Callable[[Serializer, Any], None],
     ) -> None:
-        encoded_pairs = [(_encode(key, key_encoder), val) for key, val in values.items()]
-        encoded_pairs.sort(key=lambda item: item[0])
-        self.uleb128(len(encoded_pairs))
-        for encoded_key, val in encoded_pairs:
-            self.fixed_bytes(encoded_key)
-            value_encoder(self, val)
+        encoded_values = [
+            (_encode(key, key_encoder), _encode(val, value_encoder)) for key, val in values.items()
+        ]
+        encoded_values.sort(key=lambda item: item[0])
+        self.uleb128(len(encoded_values))
+        for key, val in encoded_values:
+            self.fixed_bytes(key)
+            self.fixed_bytes(val)
 
     @staticmethod
     def sequence_serializer(

--- a/aptos_sdk/v2/crypto/mnemonic.py
+++ b/aptos_sdk/v2/crypto/mnemonic.py
@@ -54,14 +54,18 @@ def derive_ed25519_private_key(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
         )
-    change_idx = int(parts[4])
+    try:
+        account_idx = int(parts[3])
+        change_idx = int(parts[4])
+        address_idx = int(parts[5])
+    except ValueError as exc:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Non-numeric segment: {exc}"
+        ) from exc
     if change_idx != 0:
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
-
-    account_idx = int(parts[3])
-    address_idx = int(parts[5])
 
     bip44_ctx = (
         Bip44.FromSeed(seed, Bip44Coins.APTOS)
@@ -93,14 +97,18 @@ def derive_secp256k1_private_key(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
         )
-    change_idx = int(parts[4])
+    try:
+        account_idx = int(parts[3])
+        change_idx = int(parts[4])
+        address_idx = int(parts[5])
+    except ValueError as exc:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Non-numeric segment: {exc}"
+        ) from exc
     if change_idx != 0:
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
-
-    account_idx = int(parts[3])
-    address_idx = int(parts[5])
 
     bip44_ctx = (
         Bip44.FromSeed(seed, Bip44Coins.APTOS)

--- a/aptos_sdk/v2/crypto/mnemonic.py
+++ b/aptos_sdk/v2/crypto/mnemonic.py
@@ -47,12 +47,17 @@ def derive_ed25519_private_key(
 
     seed = Bip39SeedGenerator(phrase).Generate()
 
-    # Parse the BIP-44 derivation path: m/purpose'/coin'/account'/change'/address'
+    # Parse the BIP-44 derivation path: m/44'/637'/account'/change'/address'
     parts = path.replace("'", "").split("/")
-    if len(parts) < 6 or parts[0] != "m":
+    if len(parts) != 6 or parts[0] != "m" or parts[1] != "44" or parts[2] != "637":
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
+        )
+    change_idx = int(parts[4])
+    if change_idx != 0:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
 
     account_idx = int(parts[3])
@@ -81,12 +86,17 @@ def derive_secp256k1_private_key(
 
     seed = Bip39SeedGenerator(phrase).Generate()
 
-    # Parse the BIP-44 derivation path: m/purpose'/coin'/account'/change'/address'
+    # Parse the BIP-44 derivation path: m/44'/637'/account'/change'/address'
     parts = path.replace("'", "").split("/")
-    if len(parts) < 6 or parts[0] != "m":
+    if len(parts) != 6 or parts[0] != "m" or parts[1] != "44" or parts[2] != "637":
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
+        )
+    change_idx = int(parts[4])
+    if change_idx != 0:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
 
     account_idx = int(parts[3])

--- a/aptos_sdk/v2/transactions/payload.py
+++ b/aptos_sdk/v2/transactions/payload.py
@@ -31,7 +31,7 @@ class ModuleId:
     @staticmethod
     def from_str(module_id: str) -> ModuleId:
         parts = module_id.split("::")
-        if len(parts) != 2:
+        if len(parts) != 2 or not parts[0] or not parts[1]:
             raise ValueError(
                 f"Invalid module ID '{module_id}': expected format 'address::module_name'"
             )

--- a/aptos_sdk/v2/transactions/raw_transaction.py
+++ b/aptos_sdk/v2/transactions/raw_transaction.py
@@ -17,8 +17,19 @@ from .authenticator import (
 )
 from .payload import TransactionPayload
 
-_RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
-_RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
+
+def _raw_txn_prehash() -> bytes:
+    """SHA3-256 of b"APTOS::RawTransaction" — the domain separator for single-sender signing."""
+    hasher = hashlib.sha3_256()
+    hasher.update(b"APTOS::RawTransaction")
+    return hasher.digest()
+
+
+def _raw_txn_with_data_prehash() -> bytes:
+    """SHA3-256 of b"APTOS::RawTransactionWithData" — for multi-agent/fee-payer signing."""
+    hasher = hashlib.sha3_256()
+    hasher.update(b"APTOS::RawTransactionWithData")
+    return hasher.digest()
 
 
 def _sign_internal(keyed_data: bytes, key: PrivateKey) -> AccountAuthenticator:
@@ -87,7 +98,9 @@ class RawTransaction:
         """Produce the signing message: prehash || BCS(self)."""
         ser = Serializer()
         self.serialize(ser)
-        return _RAW_TXN_PREHASH + ser.output()
+        prehash = bytearray(_raw_txn_prehash())
+        prehash.extend(ser.output())
+        return bytes(prehash)
 
     def sign(self, private_key: PrivateKey) -> AccountAuthenticator:
         return _sign_internal(self.keyed(), private_key)
@@ -137,7 +150,9 @@ class MultiAgentRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        return _RAW_TXN_WITH_DATA_PREHASH + ser.output()
+        prehash = bytearray(_raw_txn_with_data_prehash())
+        prehash.extend(ser.output())
+        return bytes(prehash)
 
     def sign(self, private_key: PrivateKey) -> AccountAuthenticator:
         return _sign_internal(self.keyed(), private_key)
@@ -182,7 +197,9 @@ class FeePayerRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        return _RAW_TXN_WITH_DATA_PREHASH + ser.output()
+        prehash = bytearray(_raw_txn_with_data_prehash())
+        prehash.extend(ser.output())
+        return bytes(prehash)
 
     def sign(self, private_key: PrivateKey) -> AccountAuthenticator:
         return _sign_internal(self.keyed(), private_key)

--- a/aptos_sdk/v2/transactions/raw_transaction.py
+++ b/aptos_sdk/v2/transactions/raw_transaction.py
@@ -17,19 +17,8 @@ from .authenticator import (
 )
 from .payload import TransactionPayload
 
-
-def _raw_txn_prehash() -> bytes:
-    """SHA3-256 of b"APTOS::RawTransaction" — the domain separator for single-sender signing."""
-    hasher = hashlib.sha3_256()
-    hasher.update(b"APTOS::RawTransaction")
-    return hasher.digest()
-
-
-def _raw_txn_with_data_prehash() -> bytes:
-    """SHA3-256 of b"APTOS::RawTransactionWithData" — for multi-agent/fee-payer signing."""
-    hasher = hashlib.sha3_256()
-    hasher.update(b"APTOS::RawTransactionWithData")
-    return hasher.digest()
+_RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
+_RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
 
 
 def _sign_internal(keyed_data: bytes, key: PrivateKey) -> AccountAuthenticator:
@@ -98,7 +87,7 @@ class RawTransaction:
         """Produce the signing message: prehash || BCS(self)."""
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_prehash())
+        prehash = bytearray(_RAW_TXN_PREHASH)
         prehash.extend(ser.output())
         return bytes(prehash)
 
@@ -150,7 +139,7 @@ class MultiAgentRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_with_data_prehash())
+        prehash = bytearray(_RAW_TXN_WITH_DATA_PREHASH)
         prehash.extend(ser.output())
         return bytes(prehash)
 
@@ -197,7 +186,7 @@ class FeePayerRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_with_data_prehash())
+        prehash = bytearray(_RAW_TXN_WITH_DATA_PREHASH)
         prehash.extend(ser.output())
         return bytes(prehash)
 

--- a/aptos_sdk/v2/transactions/raw_transaction.py
+++ b/aptos_sdk/v2/transactions/raw_transaction.py
@@ -17,6 +17,9 @@ from .authenticator import (
 )
 from .payload import TransactionPayload
 
+# Domain-separator prehashes for transaction signing (keyed = prehash || BCS(txn)).
+# Single-sender transactions use APTOS::RawTransaction; multi-agent and fee-payer
+# transactions use APTOS::RawTransactionWithData.
 _RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
 _RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
 

--- a/aptos_sdk/v2/types/type_tag.py
+++ b/aptos_sdk/v2/types/type_tag.py
@@ -24,6 +24,21 @@ class TypeTagVariant:
     U256 = 10
 
 
+# Maps variant discriminant → canonical type-name string used by TypeTag.__str__.
+# Only primitive variants appear here; VectorTag and StructTag have their own __str__.
+_PRIMITIVE_TYPE_NAMES: dict[int, str] = {
+    TypeTagVariant.BOOL: "bool",
+    TypeTagVariant.U8: "u8",
+    TypeTagVariant.U16: "u16",
+    TypeTagVariant.U32: "u32",
+    TypeTagVariant.U64: "u64",
+    TypeTagVariant.U128: "u128",
+    TypeTagVariant.U256: "u256",
+    TypeTagVariant.ACCOUNT_ADDRESS: "address",
+    TypeTagVariant.SIGNER: "signer",
+}
+
+
 # --- Primitive tag classes ---
 
 
@@ -291,7 +306,10 @@ class TypeTag:
         return self.value.variant() == other.value.variant() and self.value == other.value
 
     def __str__(self) -> str:
-        return str(self.value)
+        # Primitive variants render as their Move type name (e.g. "u64"), not their
+        # placeholder value; VectorTag and StructTag provide their own __str__.
+        name = _PRIMITIVE_TYPE_NAMES.get(self.value.variant())
+        return name if name is not None else str(self.value)
 
     def __repr__(self) -> str:
         return str(self)
@@ -300,24 +318,26 @@ class TypeTag:
     def deserialize(deserializer: Deserializer) -> TypeTag:
         variant = deserializer.uleb128()
         match variant:
+            # Primitive variants carry no BCS payload after the discriminant.
             case TypeTagVariant.BOOL:
-                return TypeTag(BoolTag.deserialize(deserializer))
+                return TypeTag(BoolTag(False))
             case TypeTagVariant.U8:
-                return TypeTag(U8Tag.deserialize(deserializer))
+                return TypeTag(U8Tag(0))
             case TypeTagVariant.U16:
-                return TypeTag(U16Tag.deserialize(deserializer))
+                return TypeTag(U16Tag(0))
             case TypeTagVariant.U32:
-                return TypeTag(U32Tag.deserialize(deserializer))
+                return TypeTag(U32Tag(0))
             case TypeTagVariant.U64:
-                return TypeTag(U64Tag.deserialize(deserializer))
+                return TypeTag(U64Tag(0))
             case TypeTagVariant.U128:
-                return TypeTag(U128Tag.deserialize(deserializer))
+                return TypeTag(U128Tag(0))
             case TypeTagVariant.U256:
-                return TypeTag(U256Tag.deserialize(deserializer))
+                return TypeTag(U256Tag(0))
             case TypeTagVariant.ACCOUNT_ADDRESS:
-                return TypeTag(AccountAddressTag.deserialize(deserializer))
+                return TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32)))
             case TypeTagVariant.SIGNER:
-                return TypeTag(SignerTag.deserialize(deserializer))
+                return TypeTag(SignerTag())
+            # Composite variants do have inner BCS data.
             case TypeTagVariant.VECTOR:
                 return TypeTag(VectorTag.deserialize(deserializer))
             case TypeTagVariant.STRUCT:
@@ -327,7 +347,10 @@ class TypeTag:
 
     def serialize(self, serializer: Serializer) -> None:
         serializer.uleb128(self.value.variant())
-        serializer.struct(self.value)
+        # Primitive variants (bool, u8 … u256, address, signer) are pure discriminants
+        # in the Aptos BCS TypeTag encoding — no payload follows the variant byte.
+        if isinstance(self.value, (VectorTag, StructTag)):
+            serializer.struct(self.value)
 
     @staticmethod
     def from_str(type_tag: str) -> TypeTag:
@@ -348,28 +371,34 @@ class TypeTag:
 
 # --- Parser for string representation ---
 
-_PRIMITIVE_TAGS: dict[str, TypeTag] = {}
-
 
 def _primitive_tag(name: str) -> TypeTag | None:
-    """Return the primitive ``TypeTag`` for ``name``, or ``None`` if not primitive."""
-    if not _PRIMITIVE_TAGS:
-        # Built lazily because TypeTag isn't constructible at module import time
-        # for the dataclass slots dance.
-        _PRIMITIVE_TAGS.update(
-            {
-                "bool": TypeTag(BoolTag(False)),
-                "u8": TypeTag(U8Tag(0)),
-                "u16": TypeTag(U16Tag(0)),
-                "u32": TypeTag(U32Tag(0)),
-                "u64": TypeTag(U64Tag(0)),
-                "u128": TypeTag(U128Tag(0)),
-                "u256": TypeTag(U256Tag(0)),
-                "address": TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32))),
-                "signer": TypeTag(SignerTag()),
-            }
-        )
-    return _PRIMITIVE_TAGS.get(name)
+    """Return a fresh primitive ``TypeTag`` for ``name``, or ``None`` if not primitive.
+
+    A new instance is returned each call so that callers cannot accidentally
+    mutate a shared singleton (TypeTag is not frozen).
+    """
+    match name:
+        case "bool":
+            return TypeTag(BoolTag(False))
+        case "u8":
+            return TypeTag(U8Tag(0))
+        case "u16":
+            return TypeTag(U16Tag(0))
+        case "u32":
+            return TypeTag(U32Tag(0))
+        case "u64":
+            return TypeTag(U64Tag(0))
+        case "u128":
+            return TypeTag(U128Tag(0))
+        case "u256":
+            return TypeTag(U256Tag(0))
+        case "address":
+            return TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32)))
+        case "signer":
+            return TypeTag(SignerTag())
+        case _:
+            return None
 
 
 def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:

--- a/aptos_sdk/v2/types/type_tag.py
+++ b/aptos_sdk/v2/types/type_tag.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
 
 from ..bcs import Deserializer, Serializer
 from ..errors import InvalidTypeTagError
@@ -233,7 +232,6 @@ class StructTag:
         return value
 
     @staticmethod
-    @lru_cache(maxsize=256)
     def from_str(type_tag: str) -> StructTag:
         tags, _ = _parse_type_tags(type_tag, 0)
         if not tags:  # pragma: no cover — parser always appends via _make_struct_tag
@@ -303,7 +301,14 @@ class TypeTag:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TypeTag):
             return NotImplemented
-        return self.value.variant() == other.value.variant() and self.value == other.value
+        v1, v2 = self.value.variant(), other.value.variant()
+        if v1 != v2:
+            return False
+        # Primitive variants carry no BCS payload; two TypeTags with the same primitive
+        # variant represent the same Move type regardless of any placeholder value.
+        if v1 in _PRIMITIVE_TYPE_NAMES:
+            return True
+        return self.value == other.value
 
     def __str__(self) -> str:
         # Primitive variants render as their Move type name (e.g. "u64"), not their

--- a/aptos_sdk/v2/types/type_tag.py
+++ b/aptos_sdk/v2/types/type_tag.py
@@ -411,6 +411,7 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
     name = ""
     tags: list[TypeTag] = []
     inner_tags: list[TypeTag] = []
+    saw_generics = False
 
     while index < len(type_tag):
         letter = type_tag[index]
@@ -419,11 +420,21 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
         if letter == " ":
             continue
         elif letter == "<":
+            # Reject a second generic argument list on the same token, e.g.
+            # ``vector<u8><u16>``. Without this guard the second list would
+            # silently overwrite ``inner_tags`` and yield an incorrect tag.
+            if saw_generics:
+                raise InvalidTypeTagError(
+                    f"Unexpected '<' in type tag: a token may have at most one "
+                    f"generic argument list, got {type_tag!r}"
+                )
             inner_tags, index = _parse_type_tags(type_tag, index)
+            saw_generics = True
         elif letter == ",":
             tags.append(_make_tag(name, inner_tags))
             name = ""
             inner_tags = []
+            saw_generics = False
         elif letter == ">":
             break
         else:

--- a/aptos_sdk/v2/types/type_tag.py
+++ b/aptos_sdk/v2/types/type_tag.py
@@ -329,12 +329,51 @@ class TypeTag:
         serializer.uleb128(self.value.variant())
         serializer.struct(self.value)
 
+    @staticmethod
+    def from_str(type_tag: str) -> TypeTag:
+        """Parse a Move type-tag string into a :class:`TypeTag`.
+
+        Supports:
+            * primitives: ``bool``, ``u8`` … ``u256``, ``address``, ``signer``
+            * vectors: ``vector<inner>``
+            * structs: ``addr::module::name<...>``
+
+        Raises :class:`InvalidTypeTagError` on malformed input.
+        """
+        tags, _ = _parse_type_tags(type_tag, 0)
+        if len(tags) != 1:
+            raise InvalidTypeTagError(f"Expected exactly one type tag, got {len(tags)}")
+        return tags[0]
+
 
 # --- Parser for string representation ---
 
+_PRIMITIVE_TAGS: dict[str, TypeTag] = {}
+
+
+def _primitive_tag(name: str) -> TypeTag | None:
+    """Return the primitive ``TypeTag`` for ``name``, or ``None`` if not primitive."""
+    if not _PRIMITIVE_TAGS:
+        # Built lazily because TypeTag isn't constructible at module import time
+        # for the dataclass slots dance.
+        _PRIMITIVE_TAGS.update(
+            {
+                "bool": TypeTag(BoolTag(False)),
+                "u8": TypeTag(U8Tag(0)),
+                "u16": TypeTag(U16Tag(0)),
+                "u32": TypeTag(U32Tag(0)),
+                "u64": TypeTag(U64Tag(0)),
+                "u128": TypeTag(U128Tag(0)),
+                "u256": TypeTag(U256Tag(0)),
+                "address": TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32))),
+                "signer": TypeTag(SignerTag()),
+            }
+        )
+    return _PRIMITIVE_TAGS.get(name)
+
 
 def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
-    """Recursively parse comma-separated struct tags with nested generics."""
+    """Recursively parse comma-separated tags (struct, primitive, or vector)."""
     name = ""
     tags: list[TypeTag] = []
     inner_tags: list[TypeTag] = []
@@ -348,7 +387,7 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
         elif letter == "<":
             inner_tags, index = _parse_type_tags(type_tag, index)
         elif letter == ",":
-            tags.append(_make_struct_tag(name, inner_tags))
+            tags.append(_make_tag(name, inner_tags))
             name = ""
             inner_tags = []
         elif letter == ">":
@@ -356,13 +395,30 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
         else:
             name += letter
 
-    tags.append(_make_struct_tag(name, inner_tags))
+    tags.append(_make_tag(name, inner_tags))
     return tags, index
+
+
+def _make_tag(name: str, inner_tags: list[TypeTag]) -> TypeTag:
+    """Resolve a parsed token into a primitive, vector, or struct tag."""
+    name = name.strip()
+    if name == "vector":
+        if len(inner_tags) != 1:
+            raise InvalidTypeTagError(
+                f"vector<...> expects exactly one type argument, got {len(inner_tags)}"
+            )
+        return TypeTag(VectorTag(inner_tags[0]))
+    primitive = _primitive_tag(name)
+    if primitive is not None:
+        if inner_tags:
+            raise InvalidTypeTagError(f"Primitive type {name!r} does not take type arguments")
+        return primitive
+    return _make_struct_tag(name, inner_tags)
 
 
 def _make_struct_tag(name: str, inner_tags: list[TypeTag]) -> TypeTag:
     parts = name.split("::")
-    if len(parts) != 3:
+    if len(parts) != 3 or not all(parts):
         raise InvalidTypeTagError(f"Invalid struct tag format: {name}")
     return TypeTag(
         StructTag(

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,7 +20,8 @@ coverage:
         threshold: 1%
         informational: false
       v1-sdk:
-        target: 88%
+        # Matches the ≥ 90 % goal documented in README.md "Test coverage".
+        target: 90%
         threshold: 1%
         flags:
           - v1-sdk

--- a/codecov.yml
+++ b/codecov.yml
@@ -20,12 +20,12 @@ coverage:
         threshold: 1%
         informational: false
       v1-sdk:
-        target: auto
+        target: 88%
         threshold: 1%
         flags:
           - v1-sdk
       v2-sdk:
-        target: auto
+        target: 95%
         threshold: 1%
         flags:
           - v2-sdk
@@ -53,13 +53,12 @@ comment:
   require_changes: false
   show_carryforward_flags: true
 
-# Files under aptos_sdk/v2/ are a mirror of v2/src/aptos_sdk_v2; don't
-# double-count them — the v2-sdk flag covers the canonical copy.
+# Files under aptos_sdk/v2/ are byte-for-byte mirrors of v2/src/aptos_sdk_v2;
+# don't double-count them — the v2 flag covers the canonical copy.
 ignore:
   - "aptos_sdk/v2/**"
   - "**/test_*.py"
-  - "tests/**"
-  - "v2/tests/**"
+  - "**/*_test.py"
   - "examples/**"
   - "features/**"
-  - "benchmarks/**"
+  - "v2/tests/**"

--- a/codecov.yml
+++ b/codecov.yml
@@ -54,7 +54,7 @@ comment:
   show_carryforward_flags: true
 
 # Files under aptos_sdk/v2/ are byte-for-byte mirrors of v2/src/aptos_sdk_v2;
-# don't double-count them — the v2 flag covers the canonical copy.
+# don't double-count them — the v2-sdk flag covers the canonical copy.
 ignore:
   - "aptos_sdk/v2/**"
   - "**/test_*.py"

--- a/examples/e2e_smoke.py
+++ b/examples/e2e_smoke.py
@@ -1,0 +1,161 @@
+# Copyright © Aptos Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+End-to-end smoke test for the SDK against a live Aptos network.
+
+Exercises (in order):
+    1. ``RestClient.info`` and ``chain_id`` — node liveness + ID caching
+    2. ``FaucetClient.fund_account`` — account funding
+    3. ``RestClient.account_balance`` — coin / FA balance read
+    4. ``RestClient.simulate_transaction`` — pre-flight gas estimation
+    5. ``RestClient.bcs_transfer`` — APT transfer
+    6. ``RestClient.transfer_coins`` — typed coin transfer
+    7. ``RestClient.account_resources`` and ``transactions_by_account``
+    8. Optional: ``IndexerClient.query`` — graceful skip on rate limit
+
+Run against devnet (default), localnet, or testnet:
+
+.. code-block:: bash
+
+    uv run python -m examples.e2e_smoke
+    APTOS_NODE_URL=http://127.0.0.1:8080/v1 \\
+    APTOS_FAUCET_URL=http://127.0.0.1:8081 \\
+        uv run python -m examples.e2e_smoke
+
+The script exits non-zero on the first failure so it can be wired into CI as a
+single-command health check.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import traceback
+
+from aptos_sdk.account import Account
+from aptos_sdk.async_client import (
+    FaucetClient,
+    IndexerClient,
+    IndexerError,
+    RestClient,
+)
+from aptos_sdk.bcs import Serializer
+from aptos_sdk.transactions import (
+    EntryFunction,
+    TransactionArgument,
+    TransactionPayload,
+)
+
+from .common import (
+    CLIENT_CONFIG,
+    FAUCET_AUTH_TOKEN,
+    FAUCET_URL,
+    INDEXER_URL,
+    NODE_URL,
+)
+
+APTOS_COIN = "0x1::aptos_coin::AptosCoin"
+
+
+async def _step(name: str, coro):
+    print(f"  -> {name} ... ", end="", flush=True)
+    try:
+        result = await coro
+    except Exception as exc:  # surface any failure clearly
+        print(f"FAIL\n    {type(exc).__name__}: {exc}")
+        traceback.print_exc()
+        raise
+    print("OK")
+    return result
+
+
+def _transfer_payload(recipient, amount: int) -> TransactionPayload:
+    return TransactionPayload(
+        EntryFunction.natural(
+            "0x1::aptos_account",
+            "transfer",
+            [],
+            [
+                TransactionArgument(recipient, Serializer.struct),
+                TransactionArgument(amount, Serializer.u64),
+            ],
+        )
+    )
+
+
+async def main() -> int:
+    print(f"Node: {NODE_URL}")
+    print(f"Faucet: {FAUCET_URL}")
+    rest = RestClient(NODE_URL, client_config=CLIENT_CONFIG)
+    faucet = FaucetClient(FAUCET_URL, rest, FAUCET_AUTH_TOKEN)
+
+    try:
+        info = await _step("ledger info", rest.info())
+        print(f"    chain_id={info['chain_id']}, version={info['ledger_version']}")
+        chain_id = await _step("chain_id() caches", rest.chain_id())
+        assert chain_id == int(info["chain_id"])
+
+        alice = Account.generate()
+        bob = Account.generate()
+        print(f"    Alice = {alice.address()}")
+        print(f"    Bob   = {bob.address()}")
+
+        await _step(
+            "faucet.fund_account(alice)",
+            faucet.fund_account(alice.address(), 100_000_000),
+        )
+        await _step(
+            "faucet.fund_account(bob)",
+            faucet.fund_account(bob.address(), 1),
+        )
+
+        alice_balance = await _step("account_balance(alice)", rest.account_balance(alice.address()))
+        assert alice_balance > 0, "Alice was just funded; balance must be positive"
+
+        # Pre-flight simulation (uses a zero-signature authenticator).
+        raw = await rest.create_bcs_transaction(alice, _transfer_payload(bob.address(), 1))
+        sim = await _step("simulate_transaction(transfer)", rest.simulate_transaction(raw, alice))
+        assert sim and sim[0].get("success"), f"simulation failed: {sim}"
+
+        h1 = await _step(
+            "bcs_transfer(alice -> bob, 1000)",
+            rest.bcs_transfer(alice, bob.address(), 1_000),
+        )
+        await _step(f"wait_for_transaction({h1[:10]}...)", rest.wait_for_transaction(h1))
+
+        h2 = await _step(
+            "transfer_coins(alice -> bob, 1000, AptosCoin)",
+            rest.transfer_coins(alice, bob.address(), APTOS_COIN, 1_000),
+        )
+        await _step(f"wait_for_transaction({h2[:10]}...)", rest.wait_for_transaction(h2))
+
+        bob_balance = await _step("account_balance(bob)", rest.account_balance(bob.address()))
+        assert bob_balance >= 2_001, f"Bob should have at least 2001, got {bob_balance}"
+
+        await _step("account_resources(alice)", rest.account_resources(alice.address()))
+        await _step(
+            "transactions_by_account(alice)",
+            rest.transactions_by_account(alice.address(), limit=5),
+        )
+
+        if INDEXER_URL and INDEXER_URL != "none":
+            indexer = IndexerClient(INDEXER_URL)
+            try:
+                await indexer.query(
+                    "query Q { account_transactions(limit: 1) { transaction_version } }",
+                    {},
+                )
+                print("  -> indexer reachable and returned data")
+            except IndexerError as exc:
+                # The public devnet indexer is rate limited; treat as soft skip.
+                print(f"  -> indexer skipped (rate-limited or down): {exc}")
+
+        print("\nAll smoke checks passed.")
+        return 0
+    finally:
+        await rest.close()
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))

--- a/examples/fee_payer_transfer_coin.py
+++ b/examples/fee_payer_transfer_coin.py
@@ -45,7 +45,8 @@ async def main():
     print(f"Bob balance: {bob_balance}")
     print(f"Sponsor balance: {sponsor_balance}")  # <:!:section_4
 
-    # Have Alice give Bob 1_000 coins via a sponsored transaction
+    # Sponsor pays the gas for Alice to create Bob's account on chain.
+    # (No coins are transferred — the entry function is `create_account`.)
     # :!:>section_5
     transaction_arguments = [
         TransactionArgument(bob.address(), Serializer.struct),

--- a/examples/transaction_batching.py
+++ b/examples/transaction_batching.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import time
 from multiprocessing import Pipe, Process
 from multiprocessing.connection import Connection
@@ -263,6 +264,7 @@ class Accounts:
 
     @staticmethod
     def generate(path: str, num_accounts: int) -> Accounts:
+        os.makedirs(path, exist_ok=True)
         source = Account.generate()
         source.store(f"{path}/source.txt")
         senders = []

--- a/examples/transfer_coin.py
+++ b/examples/transfer_coin.py
@@ -91,10 +91,23 @@ async def main():
             if data and "data" in data and len(data["data"]["account_transactions"]) > 0:
                 break
             await asyncio.sleep(1)
-        if data is None or "data" not in data or not data["data"]["account_transactions"]:
+
+        if last_error is not None and (
+            data is None or "data" not in data or not data["data"]["account_transactions"]
+        ):
+            # Indexer was unreachable / rate-limited the whole time; soft-skip.
             print(
                 "\n=== Indexer ===\n"
                 f"Skipped indexer assertion (no data returned). Last error: {last_error}"
+            )
+        else:
+            # The indexer responded; assert it actually saw Bob's transactions
+            # so we still verify correctness end-to-end on healthy networks.
+            assert data is not None and "data" in data, (
+                f"indexer returned malformed payload: {data!r}"
+            )
+            assert len(data["data"]["account_transactions"]) > 0, (
+                "indexer returned no transactions for Bob despite no transport errors"
             )
 
     await rest_client.close()

--- a/examples/transfer_coin.py
+++ b/examples/transfer_coin.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+from typing import Optional
 
 from aptos_sdk.account import Account
-from aptos_sdk.async_client import FaucetClient, IndexerClient, RestClient
+from aptos_sdk.async_client import FaucetClient, IndexerClient, IndexerError, RestClient
 
 from .common import CLIENT_CONFIG, FAUCET_AUTH_TOKEN, FAUCET_URL, INDEXER_URL, NODE_URL
 
@@ -76,12 +77,25 @@ async def main():
         """
 
         variables = {"account": f"{bob.address()}"}
-        for i in range(20):
-            data = await indexer_client.query(query, variables)
-            if "data" in data and len(data["data"]["account_transactions"]) > 0:
+        data = None
+        last_error: Optional[Exception] = None
+        for _ in range(20):
+            try:
+                data = await indexer_client.query(query, variables)
+            except IndexerError as exc:
+                # The public devnet indexer is heavily rate-limited; treat that
+                # as a soft failure for the example rather than crashing.
+                last_error = exc
+                await asyncio.sleep(1)
+                continue
+            if data and "data" in data and len(data["data"]["account_transactions"]) > 0:
                 break
             await asyncio.sleep(1)
-        assert "data" in data and len(data["data"]["account_transactions"]) > 0
+        if data is None or "data" not in data or not data["data"]["account_transactions"]:
+            print(
+                "\n=== Indexer ===\n"
+                f"Skipped indexer assertion (no data returned). Last error: {last_error}"
+            )
 
     await rest_client.close()
 

--- a/examples/transfer_coin.py
+++ b/examples/transfer_coin.py
@@ -89,6 +89,7 @@ async def main():
                 await asyncio.sleep(1)
                 continue
             if data and "data" in data and len(data["data"]["account_transactions"]) > 0:
+                last_error = None  # successful response — don't soft-skip
                 break
             await asyncio.sleep(1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,12 @@ source = ["aptos_sdk"]
 omit = [
     "aptos_sdk/**/test_*.py",
     "aptos_sdk/**/*_test.py",
+    # The v2 mirror under aptos_sdk/v2 is a byte-for-byte copy of
+    # v2/src/aptos_sdk_v2 (enforced by .github/scripts/check_v2_sync.sh)
+    # and is exercised by the standalone v2 test suite, which uploads
+    # its own coverage report. Counting it here would double-penalize
+    # tests that intentionally live in v2/tests/.
+    "aptos_sdk/v2/**",
 ]
 
 [tool.coverage.report]

--- a/v2/src/aptos_sdk_v2/api/account_api.py
+++ b/v2/src/aptos_sdk_v2/api/account_api.py
@@ -35,7 +35,7 @@ class AccountApi:
         which handles both legacy coins and fungible assets.
         """
         url = f"{self._config.node_url}/accounts/{address}/balance/{asset_type}"
-        result = await self._client.get(url)
+        result: Any = await self._client.get(url)
         return int(result)
 
     async def get_resource(self, address: AccountAddress, resource_type: str) -> dict[str, Any]:

--- a/v2/src/aptos_sdk_v2/api/general_api.py
+++ b/v2/src/aptos_sdk_v2/api/general_api.py
@@ -89,11 +89,11 @@ class GeneralApi:
         """
         from ..bcs import Serializer
         from ..transactions.payload import ModuleId
-        from ..types.type_tag import TypeTag
+        from ..types.type_tag import StructTag, TypeTag
 
         # Build the BCS payload for the view request
         module_id = ModuleId.from_str(module)
-        parsed_ty_args = [TypeTag.from_str(t) for t in ty_args] if ty_args else []
+        parsed_ty_args = [TypeTag(StructTag.from_str(t)) for t in ty_args] if ty_args else []
 
         ser = Serializer()
         module_id.serialize(ser)

--- a/v2/src/aptos_sdk_v2/api/general_api.py
+++ b/v2/src/aptos_sdk_v2/api/general_api.py
@@ -89,11 +89,13 @@ class GeneralApi:
         """
         from ..bcs import Serializer
         from ..transactions.payload import ModuleId
-        from ..types.type_tag import StructTag, TypeTag
+        from ..types.type_tag import TypeTag
 
-        # Build the BCS payload for the view request
+        # Build the BCS payload for the view request. ``TypeTag.from_str``
+        # supports primitives (``u64``, ``bool``, ``address``…), ``vector<T>``,
+        # and structs — anything the on-chain ABI accepts.
         module_id = ModuleId.from_str(module)
-        parsed_ty_args = [TypeTag(StructTag.from_str(t)) for t in ty_args] if ty_args else []
+        parsed_ty_args = [TypeTag.from_str(t) for t in ty_args] if ty_args else []
 
         ser = Serializer()
         module_id.serialize(ser)

--- a/v2/src/aptos_sdk_v2/bcs/serializer.py
+++ b/v2/src/aptos_sdk_v2/bcs/serializer.py
@@ -154,7 +154,7 @@ class Serializer:
     ) -> None:
         self.uleb128(len(values))
         for value in values:
-            self.fixed_bytes(_encode(value, value_encoder))
+            value_encoder(self, value)
 
     def map(
         self,

--- a/v2/src/aptos_sdk_v2/crypto/authentication_key.py
+++ b/v2/src/aptos_sdk_v2/crypto/authentication_key.py
@@ -7,6 +7,7 @@ import hashlib
 from ..types.account_address import AccountAddress, AuthKeyScheme
 from .ed25519 import Ed25519PublicKey
 from .keys import PublicKey
+from .secp256k1 import Secp256k1PublicKey
 from .single_key import AnyPublicKey
 
 
@@ -20,6 +21,10 @@ class AuthenticationKey:
 
     @staticmethod
     def from_public_key(key: PublicKey) -> AuthenticationKey:
+        # Auto-wrap non-Ed25519 keys into AnyPublicKey for single-key auth
+        if isinstance(key, Secp256k1PublicKey):
+            key = AnyPublicKey(key)
+
         hasher = hashlib.sha3_256()
         hasher.update(key.to_crypto_bytes())
 

--- a/v2/src/aptos_sdk_v2/crypto/mnemonic.py
+++ b/v2/src/aptos_sdk_v2/crypto/mnemonic.py
@@ -10,7 +10,6 @@ from bip_utils import (
     Bip44,
     Bip44Changes,
     Bip44Coins,
-    Bip44Levels,
 )
 
 from ..errors import InvalidMnemonicError
@@ -48,13 +47,16 @@ def derive_ed25519_private_key(
 
     seed = Bip39SeedGenerator(phrase).Generate()
 
-    # Parse the derivation path to extract account/change/address indices
+    # Parse the BIP-44 derivation path: m/purpose'/coin'/account'/change'/address'
     parts = path.replace("'", "").split("/")
-    if len(parts) < 5 or parts[0] != "m":
-        raise InvalidMnemonicError(f"Invalid derivation path: {path}")
+    if len(parts) < 6 or parts[0] != "m":
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. "
+            "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
+        )
 
     account_idx = int(parts[3])
-    address_idx = int(parts[4])
+    address_idx = int(parts[5])
 
     bip44_ctx = (
         Bip44.FromSeed(seed, Bip44Coins.APTOS)
@@ -62,10 +64,8 @@ def derive_ed25519_private_key(
         .Coin()
         .Account(account_idx)
         .Change(Bip44Changes.CHAIN_EXT)
+        .AddressIndex(address_idx)
     )
-
-    if bip44_ctx.IsLevel(Bip44Levels.CHANGE):
-        bip44_ctx = bip44_ctx.AddressIndex(address_idx)
 
     raw_key = bip44_ctx.PrivateKey().Raw().ToBytes()
     return Ed25519PrivateKey.from_hex(raw_key)
@@ -81,12 +81,16 @@ def derive_secp256k1_private_key(
 
     seed = Bip39SeedGenerator(phrase).Generate()
 
+    # Parse the BIP-44 derivation path: m/purpose'/coin'/account'/change'/address'
     parts = path.replace("'", "").split("/")
-    if len(parts) < 5 or parts[0] != "m":
-        raise InvalidMnemonicError(f"Invalid derivation path: {path}")
+    if len(parts) < 6 or parts[0] != "m":
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. "
+            "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
+        )
 
     account_idx = int(parts[3])
-    address_idx = int(parts[4])
+    address_idx = int(parts[5])
 
     bip44_ctx = (
         Bip44.FromSeed(seed, Bip44Coins.APTOS)
@@ -94,10 +98,8 @@ def derive_secp256k1_private_key(
         .Coin()
         .Account(account_idx)
         .Change(Bip44Changes.CHAIN_EXT)
+        .AddressIndex(address_idx)
     )
-
-    if bip44_ctx.IsLevel(Bip44Levels.CHANGE):
-        bip44_ctx = bip44_ctx.AddressIndex(address_idx)
 
     raw_key = bip44_ctx.PrivateKey().Raw().ToBytes()
     return Secp256k1PrivateKey.from_hex(raw_key)

--- a/v2/src/aptos_sdk_v2/crypto/mnemonic.py
+++ b/v2/src/aptos_sdk_v2/crypto/mnemonic.py
@@ -54,14 +54,18 @@ def derive_ed25519_private_key(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
         )
-    change_idx = int(parts[4])
+    try:
+        account_idx = int(parts[3])
+        change_idx = int(parts[4])
+        address_idx = int(parts[5])
+    except ValueError as exc:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Non-numeric segment: {exc}"
+        ) from exc
     if change_idx != 0:
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
-
-    account_idx = int(parts[3])
-    address_idx = int(parts[5])
 
     bip44_ctx = (
         Bip44.FromSeed(seed, Bip44Coins.APTOS)
@@ -93,14 +97,18 @@ def derive_secp256k1_private_key(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
         )
-    change_idx = int(parts[4])
+    try:
+        account_idx = int(parts[3])
+        change_idx = int(parts[4])
+        address_idx = int(parts[5])
+    except ValueError as exc:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Non-numeric segment: {exc}"
+        ) from exc
     if change_idx != 0:
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
-
-    account_idx = int(parts[3])
-    address_idx = int(parts[5])
 
     bip44_ctx = (
         Bip44.FromSeed(seed, Bip44Coins.APTOS)

--- a/v2/src/aptos_sdk_v2/crypto/mnemonic.py
+++ b/v2/src/aptos_sdk_v2/crypto/mnemonic.py
@@ -47,12 +47,17 @@ def derive_ed25519_private_key(
 
     seed = Bip39SeedGenerator(phrase).Generate()
 
-    # Parse the BIP-44 derivation path: m/purpose'/coin'/account'/change'/address'
+    # Parse the BIP-44 derivation path: m/44'/637'/account'/change'/address'
     parts = path.replace("'", "").split("/")
-    if len(parts) < 6 or parts[0] != "m":
+    if len(parts) != 6 or parts[0] != "m" or parts[1] != "44" or parts[2] != "637":
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
+        )
+    change_idx = int(parts[4])
+    if change_idx != 0:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
 
     account_idx = int(parts[3])
@@ -81,12 +86,17 @@ def derive_secp256k1_private_key(
 
     seed = Bip39SeedGenerator(phrase).Generate()
 
-    # Parse the BIP-44 derivation path: m/purpose'/coin'/account'/change'/address'
+    # Parse the BIP-44 derivation path: m/44'/637'/account'/change'/address'
     parts = path.replace("'", "").split("/")
-    if len(parts) < 6 or parts[0] != "m":
+    if len(parts) != 6 or parts[0] != "m" or parts[1] != "44" or parts[2] != "637":
         raise InvalidMnemonicError(
             f"Invalid derivation path: {path}. "
             "Expected BIP-44 format: m/44'/637'/account'/change'/address'"
+        )
+    change_idx = int(parts[4])
+    if change_idx != 0:
+        raise InvalidMnemonicError(
+            f"Invalid derivation path: {path}. Aptos uses change index 0 (external chain) only."
         )
 
     account_idx = int(parts[3])

--- a/v2/src/aptos_sdk_v2/transactions/payload.py
+++ b/v2/src/aptos_sdk_v2/transactions/payload.py
@@ -31,6 +31,10 @@ class ModuleId:
     @staticmethod
     def from_str(module_id: str) -> ModuleId:
         parts = module_id.split("::")
+        if len(parts) != 2:
+            raise ValueError(
+                f"Invalid module ID '{module_id}': expected format 'address::module_name'"
+            )
         return ModuleId(AccountAddress.from_str(parts[0]), parts[1])
 
     @staticmethod

--- a/v2/src/aptos_sdk_v2/transactions/payload.py
+++ b/v2/src/aptos_sdk_v2/transactions/payload.py
@@ -31,7 +31,7 @@ class ModuleId:
     @staticmethod
     def from_str(module_id: str) -> ModuleId:
         parts = module_id.split("::")
-        if len(parts) != 2:
+        if len(parts) != 2 or not parts[0] or not parts[1]:
             raise ValueError(
                 f"Invalid module ID '{module_id}': expected format 'address::module_name'"
             )

--- a/v2/src/aptos_sdk_v2/transactions/raw_transaction.py
+++ b/v2/src/aptos_sdk_v2/transactions/raw_transaction.py
@@ -17,19 +17,8 @@ from .authenticator import (
 )
 from .payload import TransactionPayload
 
-
-def _raw_txn_prehash() -> bytes:
-    """SHA3-256 of b"APTOS::RawTransaction" — the domain separator for single-sender signing."""
-    hasher = hashlib.sha3_256()
-    hasher.update(b"APTOS::RawTransaction")
-    return hasher.digest()
-
-
-def _raw_txn_with_data_prehash() -> bytes:
-    """SHA3-256 of b"APTOS::RawTransactionWithData" — for multi-agent/fee-payer signing."""
-    hasher = hashlib.sha3_256()
-    hasher.update(b"APTOS::RawTransactionWithData")
-    return hasher.digest()
+_RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
+_RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
 
 
 def _sign_internal(keyed_data: bytes, key: PrivateKey) -> AccountAuthenticator:
@@ -98,7 +87,7 @@ class RawTransaction:
         """Produce the signing message: prehash || BCS(self)."""
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_prehash())
+        prehash = bytearray(_RAW_TXN_PREHASH)
         prehash.extend(ser.output())
         return bytes(prehash)
 
@@ -150,7 +139,7 @@ class MultiAgentRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_with_data_prehash())
+        prehash = bytearray(_RAW_TXN_WITH_DATA_PREHASH)
         prehash.extend(ser.output())
         return bytes(prehash)
 
@@ -197,7 +186,7 @@ class FeePayerRawTransaction:
     def keyed(self) -> bytes:
         ser = Serializer()
         self.serialize(ser)
-        prehash = bytearray(_raw_txn_with_data_prehash())
+        prehash = bytearray(_RAW_TXN_WITH_DATA_PREHASH)
         prehash.extend(ser.output())
         return bytes(prehash)
 

--- a/v2/src/aptos_sdk_v2/transactions/raw_transaction.py
+++ b/v2/src/aptos_sdk_v2/transactions/raw_transaction.py
@@ -17,6 +17,9 @@ from .authenticator import (
 )
 from .payload import TransactionPayload
 
+# Domain-separator prehashes for transaction signing (keyed = prehash || BCS(txn)).
+# Single-sender transactions use APTOS::RawTransaction; multi-agent and fee-payer
+# transactions use APTOS::RawTransactionWithData.
 _RAW_TXN_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransaction").digest()
 _RAW_TXN_WITH_DATA_PREHASH: bytes = hashlib.sha3_256(b"APTOS::RawTransactionWithData").digest()
 

--- a/v2/src/aptos_sdk_v2/types/type_tag.py
+++ b/v2/src/aptos_sdk_v2/types/type_tag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
 
 from ..bcs import Deserializer, Serializer
 from ..errors import InvalidTypeTagError
@@ -217,6 +218,7 @@ class StructTag:
         return value
 
     @staticmethod
+    @lru_cache(maxsize=256)
     def from_str(type_tag: str) -> StructTag:
         tags, _ = _parse_type_tags(type_tag, 0)
         if not tags:  # pragma: no cover — parser always appends via _make_struct_tag

--- a/v2/src/aptos_sdk_v2/types/type_tag.py
+++ b/v2/src/aptos_sdk_v2/types/type_tag.py
@@ -327,12 +327,51 @@ class TypeTag:
         serializer.uleb128(self.value.variant())
         serializer.struct(self.value)
 
+    @staticmethod
+    def from_str(type_tag: str) -> TypeTag:
+        """Parse a Move type-tag string into a :class:`TypeTag`.
+
+        Supports:
+            * primitives: ``bool``, ``u8`` … ``u256``, ``address``, ``signer``
+            * vectors: ``vector<inner>``
+            * structs: ``addr::module::name<...>``
+
+        Raises :class:`InvalidTypeTagError` on malformed input.
+        """
+        tags, _ = _parse_type_tags(type_tag, 0)
+        if len(tags) != 1:
+            raise InvalidTypeTagError(f"Expected exactly one type tag, got {len(tags)}")
+        return tags[0]
+
 
 # --- Parser for string representation ---
 
+_PRIMITIVE_TAGS: dict[str, TypeTag] = {}
+
+
+def _primitive_tag(name: str) -> TypeTag | None:
+    """Return the primitive ``TypeTag`` for ``name``, or ``None`` if not primitive."""
+    if not _PRIMITIVE_TAGS:
+        # Built lazily because TypeTag isn't constructible at module import time
+        # for the dataclass slots dance.
+        _PRIMITIVE_TAGS.update(
+            {
+                "bool": TypeTag(BoolTag(False)),
+                "u8": TypeTag(U8Tag(0)),
+                "u16": TypeTag(U16Tag(0)),
+                "u32": TypeTag(U32Tag(0)),
+                "u64": TypeTag(U64Tag(0)),
+                "u128": TypeTag(U128Tag(0)),
+                "u256": TypeTag(U256Tag(0)),
+                "address": TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32))),
+                "signer": TypeTag(SignerTag()),
+            }
+        )
+    return _PRIMITIVE_TAGS.get(name)
+
 
 def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
-    """Recursively parse comma-separated struct tags with nested generics."""
+    """Recursively parse comma-separated tags (struct, primitive, or vector)."""
     name = ""
     tags: list[TypeTag] = []
     inner_tags: list[TypeTag] = []
@@ -346,7 +385,7 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
         elif letter == "<":
             inner_tags, index = _parse_type_tags(type_tag, index)
         elif letter == ",":
-            tags.append(_make_struct_tag(name, inner_tags))
+            tags.append(_make_tag(name, inner_tags))
             name = ""
             inner_tags = []
         elif letter == ">":
@@ -354,13 +393,30 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
         else:
             name += letter
 
-    tags.append(_make_struct_tag(name, inner_tags))
+    tags.append(_make_tag(name, inner_tags))
     return tags, index
+
+
+def _make_tag(name: str, inner_tags: list[TypeTag]) -> TypeTag:
+    """Resolve a parsed token into a primitive, vector, or struct tag."""
+    name = name.strip()
+    if name == "vector":
+        if len(inner_tags) != 1:
+            raise InvalidTypeTagError(
+                f"vector<...> expects exactly one type argument, got {len(inner_tags)}"
+            )
+        return TypeTag(VectorTag(inner_tags[0]))
+    primitive = _primitive_tag(name)
+    if primitive is not None:
+        if inner_tags:
+            raise InvalidTypeTagError(f"Primitive type {name!r} does not take type arguments")
+        return primitive
+    return _make_struct_tag(name, inner_tags)
 
 
 def _make_struct_tag(name: str, inner_tags: list[TypeTag]) -> TypeTag:
     parts = name.split("::")
-    if len(parts) != 3:
+    if len(parts) != 3 or not all(parts):
         raise InvalidTypeTagError(f"Invalid struct tag format: {name}")
     return TypeTag(
         StructTag(

--- a/v2/src/aptos_sdk_v2/types/type_tag.py
+++ b/v2/src/aptos_sdk_v2/types/type_tag.py
@@ -24,6 +24,21 @@ class TypeTagVariant:
     U256 = 10
 
 
+# Maps variant discriminant → canonical type-name string used by TypeTag.__str__.
+# Only primitive variants appear here; VectorTag and StructTag have their own __str__.
+_PRIMITIVE_TYPE_NAMES: dict[int, str] = {
+    TypeTagVariant.BOOL: "bool",
+    TypeTagVariant.U8: "u8",
+    TypeTagVariant.U16: "u16",
+    TypeTagVariant.U32: "u32",
+    TypeTagVariant.U64: "u64",
+    TypeTagVariant.U128: "u128",
+    TypeTagVariant.U256: "u256",
+    TypeTagVariant.ACCOUNT_ADDRESS: "address",
+    TypeTagVariant.SIGNER: "signer",
+}
+
+
 # --- Primitive tag classes ---
 
 
@@ -291,7 +306,10 @@ class TypeTag:
         return self.value.variant() == other.value.variant() and self.value == other.value
 
     def __str__(self) -> str:
-        return str(self.value)
+        # Primitive variants render as their Move type name (e.g. "u64"), not their
+        # placeholder value; VectorTag and StructTag provide their own __str__.
+        name = _PRIMITIVE_TYPE_NAMES.get(self.value.variant())
+        return name if name is not None else str(self.value)
 
     def __repr__(self) -> str:
         return str(self)
@@ -300,24 +318,26 @@ class TypeTag:
     def deserialize(deserializer: Deserializer) -> TypeTag:
         variant = deserializer.uleb128()
         match variant:
+            # Primitive variants carry no BCS payload after the discriminant.
             case TypeTagVariant.BOOL:
-                return TypeTag(BoolTag.deserialize(deserializer))
+                return TypeTag(BoolTag(False))
             case TypeTagVariant.U8:
-                return TypeTag(U8Tag.deserialize(deserializer))
+                return TypeTag(U8Tag(0))
             case TypeTagVariant.U16:
-                return TypeTag(U16Tag.deserialize(deserializer))
+                return TypeTag(U16Tag(0))
             case TypeTagVariant.U32:
-                return TypeTag(U32Tag.deserialize(deserializer))
+                return TypeTag(U32Tag(0))
             case TypeTagVariant.U64:
-                return TypeTag(U64Tag.deserialize(deserializer))
+                return TypeTag(U64Tag(0))
             case TypeTagVariant.U128:
-                return TypeTag(U128Tag.deserialize(deserializer))
+                return TypeTag(U128Tag(0))
             case TypeTagVariant.U256:
-                return TypeTag(U256Tag.deserialize(deserializer))
+                return TypeTag(U256Tag(0))
             case TypeTagVariant.ACCOUNT_ADDRESS:
-                return TypeTag(AccountAddressTag.deserialize(deserializer))
+                return TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32)))
             case TypeTagVariant.SIGNER:
-                return TypeTag(SignerTag.deserialize(deserializer))
+                return TypeTag(SignerTag())
+            # Composite variants do have inner BCS data.
             case TypeTagVariant.VECTOR:
                 return TypeTag(VectorTag.deserialize(deserializer))
             case TypeTagVariant.STRUCT:
@@ -327,7 +347,10 @@ class TypeTag:
 
     def serialize(self, serializer: Serializer) -> None:
         serializer.uleb128(self.value.variant())
-        serializer.struct(self.value)
+        # Primitive variants (bool, u8 … u256, address, signer) are pure discriminants
+        # in the Aptos BCS TypeTag encoding — no payload follows the variant byte.
+        if isinstance(self.value, (VectorTag, StructTag)):
+            serializer.struct(self.value)
 
     @staticmethod
     def from_str(type_tag: str) -> TypeTag:
@@ -348,28 +371,34 @@ class TypeTag:
 
 # --- Parser for string representation ---
 
-_PRIMITIVE_TAGS: dict[str, TypeTag] = {}
-
 
 def _primitive_tag(name: str) -> TypeTag | None:
-    """Return the primitive ``TypeTag`` for ``name``, or ``None`` if not primitive."""
-    if not _PRIMITIVE_TAGS:
-        # Built lazily because TypeTag isn't constructible at module import time
-        # for the dataclass slots dance.
-        _PRIMITIVE_TAGS.update(
-            {
-                "bool": TypeTag(BoolTag(False)),
-                "u8": TypeTag(U8Tag(0)),
-                "u16": TypeTag(U16Tag(0)),
-                "u32": TypeTag(U32Tag(0)),
-                "u64": TypeTag(U64Tag(0)),
-                "u128": TypeTag(U128Tag(0)),
-                "u256": TypeTag(U256Tag(0)),
-                "address": TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32))),
-                "signer": TypeTag(SignerTag()),
-            }
-        )
-    return _PRIMITIVE_TAGS.get(name)
+    """Return a fresh primitive ``TypeTag`` for ``name``, or ``None`` if not primitive.
+
+    A new instance is returned each call so that callers cannot accidentally
+    mutate a shared singleton (TypeTag is not frozen).
+    """
+    match name:
+        case "bool":
+            return TypeTag(BoolTag(False))
+        case "u8":
+            return TypeTag(U8Tag(0))
+        case "u16":
+            return TypeTag(U16Tag(0))
+        case "u32":
+            return TypeTag(U32Tag(0))
+        case "u64":
+            return TypeTag(U64Tag(0))
+        case "u128":
+            return TypeTag(U128Tag(0))
+        case "u256":
+            return TypeTag(U256Tag(0))
+        case "address":
+            return TypeTag(AccountAddressTag(AccountAddress(b"\x00" * 32)))
+        case "signer":
+            return TypeTag(SignerTag())
+        case _:
+            return None
 
 
 def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:

--- a/v2/src/aptos_sdk_v2/types/type_tag.py
+++ b/v2/src/aptos_sdk_v2/types/type_tag.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from functools import lru_cache
 
 from ..bcs import Deserializer, Serializer
 from ..errors import InvalidTypeTagError
@@ -233,7 +232,6 @@ class StructTag:
         return value
 
     @staticmethod
-    @lru_cache(maxsize=256)
     def from_str(type_tag: str) -> StructTag:
         tags, _ = _parse_type_tags(type_tag, 0)
         if not tags:  # pragma: no cover — parser always appends via _make_struct_tag
@@ -303,7 +301,14 @@ class TypeTag:
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, TypeTag):
             return NotImplemented
-        return self.value.variant() == other.value.variant() and self.value == other.value
+        v1, v2 = self.value.variant(), other.value.variant()
+        if v1 != v2:
+            return False
+        # Primitive variants carry no BCS payload; two TypeTags with the same primitive
+        # variant represent the same Move type regardless of any placeholder value.
+        if v1 in _PRIMITIVE_TYPE_NAMES:
+            return True
+        return self.value == other.value
 
     def __str__(self) -> str:
         # Primitive variants render as their Move type name (e.g. "u64"), not their

--- a/v2/src/aptos_sdk_v2/types/type_tag.py
+++ b/v2/src/aptos_sdk_v2/types/type_tag.py
@@ -411,6 +411,7 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
     name = ""
     tags: list[TypeTag] = []
     inner_tags: list[TypeTag] = []
+    saw_generics = False
 
     while index < len(type_tag):
         letter = type_tag[index]
@@ -419,11 +420,21 @@ def _parse_type_tags(type_tag: str, index: int) -> tuple[list[TypeTag], int]:
         if letter == " ":
             continue
         elif letter == "<":
+            # Reject a second generic argument list on the same token, e.g.
+            # ``vector<u8><u16>``. Without this guard the second list would
+            # silently overwrite ``inner_tags`` and yield an incorrect tag.
+            if saw_generics:
+                raise InvalidTypeTagError(
+                    f"Unexpected '<' in type tag: a token may have at most one "
+                    f"generic argument list, got {type_tag!r}"
+                )
             inner_tags, index = _parse_type_tags(type_tag, index)
+            saw_generics = True
         elif letter == ",":
             tags.append(_make_tag(name, inner_tags))
             name = ""
             inner_tags = []
+            saw_generics = False
         elif letter == ">":
             break
         else:

--- a/v2/tests/unit/test_mnemonic.py
+++ b/v2/tests/unit/test_mnemonic.py
@@ -88,3 +88,26 @@ class TestKeyDerivation:
         phrase = generate_mnemonic()
         with pytest.raises(InvalidMnemonicError, match="Invalid derivation"):
             derive_secp256k1_private_key(phrase, "bad/path")
+
+    def test_non_numeric_path_segment_raises_invalid_mnemonic(self):
+        """Non-numeric path segments must raise InvalidMnemonicError, not ValueError."""
+        from aptos_sdk_v2.crypto.mnemonic import derive_secp256k1_private_key
+
+        phrase = generate_mnemonic()
+        bad_path = "m/44'/637'/x'/0'/0'"
+        with pytest.raises(InvalidMnemonicError, match="Non-numeric segment"):
+            derive_ed25519_private_key(phrase, bad_path)
+        with pytest.raises(InvalidMnemonicError, match="Non-numeric segment"):
+            derive_secp256k1_private_key(phrase, bad_path)
+
+    def test_extra_path_segments_rejected(self):
+        """Paths with more or fewer than 6 segments must be rejected."""
+        phrase = generate_mnemonic()
+        with pytest.raises(InvalidMnemonicError):
+            derive_ed25519_private_key(phrase, "m/44'/637'/0'/0'/0'/extra")
+
+    def test_nonzero_change_index_rejected(self):
+        """Non-zero change index must raise InvalidMnemonicError."""
+        phrase = generate_mnemonic()
+        with pytest.raises(InvalidMnemonicError, match="change index"):
+            derive_ed25519_private_key(phrase, "m/44'/637'/0'/1'/0'")

--- a/v2/tests/unit/test_transactions.py
+++ b/v2/tests/unit/test_transactions.py
@@ -177,6 +177,26 @@ class TestPayloadTypes:
         result = ModuleId.deserialize(Deserializer(ser.output()))
         assert m == result
 
+    def test_module_id_from_str_rejects_invalid(self):
+        import pytest
+
+        from aptos_sdk_v2.transactions.payload import ModuleId
+
+        # Wrong number of `::` separators
+        with pytest.raises(ValueError, match="Invalid module ID"):
+            ModuleId.from_str("0x1::coin::Extra")
+        with pytest.raises(ValueError, match="Invalid module ID"):
+            ModuleId.from_str("just_a_name")
+        # Empty address half
+        with pytest.raises(ValueError, match="Invalid module ID"):
+            ModuleId.from_str("::coin")
+        # Empty module-name half
+        with pytest.raises(ValueError, match="Invalid module ID"):
+            ModuleId.from_str("0x1::")
+        # Both empty
+        with pytest.raises(ValueError, match="Invalid module ID"):
+            ModuleId.from_str("::")
+
     def test_entry_function_eq(self):
         a = EntryFunction.natural("0x1::coin", "transfer", [], [])
         b = EntryFunction.natural("0x1::coin", "transfer", [], [])

--- a/v2/tests/unit/test_type_tag.py
+++ b/v2/tests/unit/test_type_tag.py
@@ -185,3 +185,103 @@ class TestTypeTagSerialization:
         ser.uleb128(99)  # unknown variant
         with pytest.raises(InvalidTypeTagError, match="Unknown TypeTag variant"):
             TypeTag.deserialize(Deserializer(ser.output()))
+
+
+class TestTypeTagFromStr:
+    """`TypeTag.from_str` must accept primitives, vectors, and structs."""
+
+    def test_primitives(self):
+        from aptos_sdk_v2.types.type_tag import (
+            AccountAddressTag,
+            BoolTag,
+            SignerTag,
+            U8Tag,
+            U16Tag,
+            U32Tag,
+            U64Tag,
+            U128Tag,
+            U256Tag,
+        )
+
+        cases = {
+            "bool": BoolTag,
+            "u8": U8Tag,
+            "u16": U16Tag,
+            "u32": U32Tag,
+            "u64": U64Tag,
+            "u128": U128Tag,
+            "u256": U256Tag,
+            "address": AccountAddressTag,
+            "signer": SignerTag,
+        }
+        for name, cls in cases.items():
+            tag = TypeTag.from_str(name)
+            assert isinstance(tag.value, cls), f"{name!r} did not parse to {cls.__name__}"
+
+    def test_vector(self):
+        from aptos_sdk_v2.types.type_tag import U8Tag, VectorTag
+
+        tag = TypeTag.from_str("vector<u8>")
+        assert isinstance(tag.value, VectorTag)
+        assert isinstance(tag.value.element_type.value, U8Tag)
+
+    def test_nested_vector(self):
+        from aptos_sdk_v2.types.type_tag import U64Tag, VectorTag
+
+        tag = TypeTag.from_str("vector<vector<u64>>")
+        outer = tag.value
+        assert isinstance(outer, VectorTag)
+        inner = outer.element_type.value
+        assert isinstance(inner, VectorTag)
+        assert isinstance(inner.element_type.value, U64Tag)
+
+    def test_struct(self):
+        tag = TypeTag.from_str("0x1::aptos_coin::AptosCoin")
+        assert isinstance(tag.value, StructTag)
+        assert str(tag) == "0x1::aptos_coin::AptosCoin"
+
+    def test_struct_with_primitive_generic(self):
+        # Previously `view_bcs` would crash on this because it always wrapped
+        # in StructTag.from_str.
+        from aptos_sdk_v2.types.type_tag import U64Tag
+
+        tag = TypeTag.from_str("0x1::demo::Box<u64>")
+        assert isinstance(tag.value, StructTag)
+        assert len(tag.value.type_args) == 1
+        assert isinstance(tag.value.type_args[0].value, U64Tag)
+
+    def test_vector_arity_validation(self):
+        import pytest
+
+        from aptos_sdk_v2.errors import InvalidTypeTagError
+
+        with pytest.raises(InvalidTypeTagError, match="exactly one type argument"):
+            TypeTag.from_str("vector<u8, u16>")
+
+    def test_primitive_with_type_args_rejected(self):
+        import pytest
+
+        from aptos_sdk_v2.errors import InvalidTypeTagError
+
+        with pytest.raises(InvalidTypeTagError, match="does not take type arguments"):
+            TypeTag.from_str("u64<u8>")
+
+    def test_unparseable_raises(self):
+        import pytest
+
+        from aptos_sdk_v2.errors import InvalidTypeTagError
+
+        with pytest.raises(InvalidTypeTagError):
+            TypeTag.from_str("not_a_type")
+        with pytest.raises(InvalidTypeTagError):
+            TypeTag.from_str("0x1::missing_name::")
+        with pytest.raises(InvalidTypeTagError):
+            TypeTag.from_str("::no::address")
+
+    def test_more_than_one_tag_rejected(self):
+        import pytest
+
+        from aptos_sdk_v2.errors import InvalidTypeTagError
+
+        with pytest.raises(InvalidTypeTagError, match="exactly one type tag"):
+            TypeTag.from_str("0x1::a::A, 0x1::b::B")

--- a/v2/tests/unit/test_type_tag.py
+++ b/v2/tests/unit/test_type_tag.py
@@ -57,7 +57,13 @@ class TestTypeTagSerialization:
         result = TypeTag.deserialize(der)
         assert tag == result
 
-    def test_primitive_tags_round_trip(self):
+    def test_primitive_tags_bcs_encoding(self):
+        """TypeTag BCS for primitives is a single discriminant byte — no value payload.
+
+        In the Aptos BCS TypeTag encoding, primitive variants (bool, u8 … u256,
+        address, signer) carry no inner data after the variant discriminant.  Only
+        VectorTag and StructTag have additional BCS payload.
+        """
         from aptos_sdk_v2.bcs import Deserializer, Serializer
         from aptos_sdk_v2.types.account_address import AccountAddress
         from aptos_sdk_v2.types.type_tag import (
@@ -84,14 +90,23 @@ class TestTypeTagSerialization:
         for tag in cases:
             ser = Serializer()
             tag.serialize(ser)
-            result = TypeTag.deserialize(Deserializer(ser.output()))
-            assert tag == result, f"Failed for {tag}"
+            data = ser.output()
+            # ULEB128 of any variant < 128 encodes as a single byte.
+            assert len(data) == 1, f"Expected 1-byte discriminant for {tag}, got {data.hex()}"
+            result = TypeTag.deserialize(Deserializer(data))
+            assert isinstance(result.value, type(tag.value)), (
+                f"Wrong type after round-trip for {tag}"
+            )
 
     def test_primitive_tag_str(self):
+        """Individual tag __str__ still returns the value; TypeTag wrapper returns the type name."""
         from aptos_sdk_v2.types.type_tag import BoolTag, U64Tag
 
         assert str(BoolTag(True)) == "True"
         assert str(U64Tag(123)) == "123"
+        # TypeTag wrapper must render the Move type name, not the placeholder value.
+        assert str(TypeTag(BoolTag(True))) == "bool"
+        assert str(TypeTag(U64Tag(123))) == "u64"
 
     def test_type_tag_eq_ne(self):
         a = TypeTag(StructTag.from_str("0x1::coin::Coin"))
@@ -217,6 +232,10 @@ class TestTypeTagFromStr:
         for name, cls in cases.items():
             tag = TypeTag.from_str(name)
             assert isinstance(tag.value, cls), f"{name!r} did not parse to {cls.__name__}"
+            # The TypeTag wrapper must render back to the canonical type name string.
+            assert str(tag) == name, (
+                f"str(TypeTag.from_str({name!r})) != {name!r}, got {str(tag)!r}"
+            )
 
     def test_vector(self):
         from aptos_sdk_v2.types.type_tag import U8Tag, VectorTag

--- a/v2/tests/unit/test_type_tag.py
+++ b/v2/tests/unit/test_type_tag.py
@@ -315,3 +315,26 @@ class TestTypeTagFromStr:
 
         with pytest.raises(InvalidTypeTagError, match="exactly one type tag"):
             TypeTag.from_str("0x1::a::A, 0x1::b::B")
+
+    def test_double_generics_rejected(self):
+        """A token may carry at most one ``<...>``; a second one is malformed."""
+        import pytest
+
+        from aptos_sdk_v2.errors import InvalidTypeTagError
+
+        # Without the guard the second `<u16>` would silently overwrite the
+        # first generic list, producing a `vector<u16>` instead of an error.
+        with pytest.raises(InvalidTypeTagError, match="at most one"):
+            TypeTag.from_str("vector<u8><u16>")
+        with pytest.raises(InvalidTypeTagError, match="at most one"):
+            TypeTag.from_str("0x1::a::A<u8><u16>")
+        # Same shape inside a vector element is also rejected.
+        with pytest.raises(InvalidTypeTagError, match="at most one"):
+            TypeTag.from_str("vector<vector<u8><u16>>")
+
+    def test_double_generics_in_comma_list_resets(self):
+        """A `,` separator resets the per-token state — second token may carry generics."""
+        # ``Pair<u8, vector<u16>>`` is valid: the second element starts fresh.
+        tag = TypeTag.from_str("0x1::pair::Pair<u8, vector<u16>>")
+        assert isinstance(tag.value, StructTag)
+        assert len(tag.value.type_args) == 2

--- a/v2/tests/unit/test_type_tag.py
+++ b/v2/tests/unit/test_type_tag.py
@@ -116,6 +116,17 @@ class TestTypeTagSerialization:
         assert a != c
         assert a != "not a tag"
 
+    def test_primitive_type_tag_eq_ignores_placeholder_value(self):
+        """Two TypeTags of the same primitive variant compare equal regardless of placeholder."""
+        from aptos_sdk_v2.types.type_tag import BoolTag, U64Tag
+
+        # BoolTag(True) and BoolTag(False) both represent the Move type `bool`.
+        assert TypeTag(BoolTag(True)) == TypeTag(BoolTag(False))
+        # U64Tag with different numeric placeholders are the same `u64` type.
+        assert TypeTag(U64Tag(0)) == TypeTag(U64Tag(999))
+        # Different primitive variants are still unequal.
+        assert TypeTag(BoolTag(False)) != TypeTag(U64Tag(0))
+
     def test_type_tag_str(self):
         tag = TypeTag(StructTag.from_str("0x1::aptos_coin::AptosCoin"))
         assert str(tag) == "0x1::aptos_coin::AptosCoin"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Description

Full audit of the SDK requested in the task. Highlights:

- **Coverage of `aptos_sdk/` raised from 66 % → 90 %** (`make test-coverage`). Test count went from 54 to 161. All v1 modules except CLI subprocess wrappers now sit at ≥ 80 %; previously-untouched modules (`async_client`, `aptos_token_client`, `aptos_tokenv1_client`, `package_publisher`, `cli`) all gained dedicated unit tests using `httpx.MockTransport` instead of network calls so they run in < 3 s.
- **All v1 tests now actually assert something** — the audit confirmed the existing inline `Test` classes already had real assertions; the new `aptos_sdk/extra_test.py` (107 tests) follows the same pattern. The file uses the `*_test.py` naming so it is excluded from coverage counting (matches the `omit` glob in `pyproject.toml`).
- **All currently-enabled devnet examples were re-run end-to-end** and pass: `aptos_token`, `fee_payer_transfer_coin`, `multikey`, `rotate_key`, `read_aggregator`, `secp256k1_ecdsa_transfer_coin`, `simple_aptos_token`, `simple_nft`, `simulate_transfer_coin`, `transfer_coin`, `transfer_two_by_two`. Two example bugs fixed (see F-06/F-07 below).
- **New `examples/e2e_smoke.py`** wired into `make smoke` and `make examples` — a single-command health check exercising 8 layers of the stack (`info`, `chain_id`, `faucet`, `balance`, `simulate`, `bcs_transfer`, `transfer_coins`, `account_resources`/`transactions_by_account`, indexer with graceful rate-limit skip).
- **Security review** in `SECURITY_REVIEW.md`: 7 issues fixed in this PR (F-01..F-07) and 9 pre-existing findings catalogued for follow-up (O-01..O-09).
- **Codecov was already enabled**; this PR adds `codecov.yml` with split `v1-sdk` / `v2-sdk` flags, ignores the `aptos_sdk/v2` mirror so it isn't double-counted, sets per-flag targets (88 % / 95 %), and adds the badge to the README.

#### Bugs fixed in this PR

| ID | Severity | What |
|----|----------|------|
| F-01 | High (correctness) | `ScriptArgument.__init__` rejected variants 6/7/8 (U16/U32/U256) even though `serialize`/`deserialize` supported them. |
| F-02 | Medium | `asymmetric_crypto_wrapper.PublicKey.deserialize` referenced `Signature.SECP256K1_ECDSA` instead of `PublicKey.SECP256K1_ECDSA` (worked by accident — both equal `1`). |
| F-03 | Medium | `IndexerClient.query` propagated raw `aiohttp.ContentTypeError` when the indexer returned an HTML rate-limit page; now wrapped in a new `IndexerError`, which also catches GraphQL-level `errors`. |
| F-04 | Low | `FaucetClient.healthy` accepted any 5xx response containing `tap:ok` and crashed on transport errors. Now requires `status_code == 200`. |
| F-05 | Low | The `aptos_sdk/v2` in-tree mirror had drifted ahead of the standalone `v2/src/aptos_sdk_v2` package (BIP-44 path validation, secp256k1 wrapping, `ModuleId.from_str` validation). Ported the fixes back, then added `.github/scripts/check_v2_sync.sh` and a CI step to enforce mirror parity going forward. |
| F-06 | Low | `examples/transaction_batching.py` crashed with `FileNotFoundError` because `nodes/` wasn't created. |
| F-07 | Informational | `examples/fee_payer_transfer_coin.py` comment claimed "give Bob 1_000 coins" but the entry function is `0x1::aptos_account::create_account`. |

### Test Plan

```bash
make fmt && make lint   # green
make test               # 162 unit tests + 248 BDD scenarios
make test-coverage      # TOTAL 90% (was 66%)
make smoke              # against devnet
make examples           # all 12 examples pass
cd v2 && uv run pytest tests/unit -q   # 398 tests still pass after mirror sync
bash .github/scripts/check_v2_sync.sh  # mirror enforcement
```

#### Coverage delta

| Module | Before | After |
|---|---|---|
| `aptos_sdk/` overall | 66 % | **90 %** |
| `aptos_token_client.py` | 42 % | 96 % |
| `aptos_tokenv1_client.py` | 32 % | 98 % |
| `package_publisher.py` | 27 % | 95 % |
| `cli.py` | 30 % | 94 % |
| `async_client.py` | 36 % | 92 % |
| `transactions.py` | 74 % | 95 % |
| `type_tag.py` | 71 % | 100 % |
| `account.py` | 92 % | 100 % |

### Related Links

* `SECURITY_REVIEW.md` (added in this PR)
* `examples/e2e_smoke.py` (added in this PR)
* `.github/scripts/check_v2_sync.sh` (added in this PR)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c78a222c-7f70-4f0a-a80c-b1248265d2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c78a222c-7f70-4f0a-a80c-b1248265d2e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

