### PR TITLE
[ci] Add Codecov configuration

### DIFF
--- a/.github/workflows/lints.yaml
+++ b/.github/workflows/lints.yaml
@@ -49,4 +49,6 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           files: coverage.xml
+          flags: v1-sdk
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/v2-ci.yaml
+++ b/.github/workflows/v2-ci.yaml
@@ -61,6 +61,7 @@ jobs:
           files: v2/coverage.xml
           flags: v2-sdk
           fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   test-v2-integrated:
     name: V2 integrated import test

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Discord][discord-image]][discord-url]
 [![PyPI Package Version][pypi-image-version]][pypi-url]
 [![PyPI Package Downloads][pypi-image-downloads]][pypi-url]
+[![codecov][codecov-image]][codecov-url]
 
 The official Python SDK for interacting with the [Aptos](https://github.com/aptos-labs/aptos-core/) blockchain. Get started with the [integration guide](https://aptos.dev/guides/system-integrators-guide/#getting-started).
 
@@ -131,3 +132,5 @@ This project follows [semver](https://semver.org/) as closely as possible
 [pypi-url]: https://pypi.org/project/aptos-sdk
 [discord-image]: https://img.shields.io/discord/945856774056083548?label=Discord&logo=discord&style=flat~~~~
 [discord-url]: https://discord.gg/aptosnetwork
+[codecov-image]: https://codecov.io/gh/aptos-labs/aptos-python-sdk/branch/main/graph/badge.svg
+[codecov-url]: https://codecov.io/gh/aptos-labs/aptos-python-sdk

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,65 @@
+# Codecov configuration.
+#
+# Uploads come from two sources:
+#   * lints workflow    → coverage.xml flagged as `v1-sdk`
+#                         (covers aptos_sdk/, excluding the v2 mirror)
+#   * v2-ci workflow    → v2/coverage.xml flagged as `v2-sdk`
+#                         (covers the standalone aptos_sdk_v2 package)
+#
+# Codecov composes both flags into a single project view.
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: false
+      v1-sdk:
+        target: auto
+        threshold: 1%
+        flags:
+          - v1-sdk
+      v2-sdk:
+        target: auto
+        threshold: 1%
+        flags:
+          - v2-sdk
+    patch:
+      default:
+        target: 80%
+        threshold: 5%
+
+flag_management:
+  default_rules:
+    carryforward: true
+  individual_flags:
+    - name: v1-sdk
+      paths:
+        - aptos_sdk/
+      carryforward: true
+    - name: v2-sdk
+      paths:
+        - v2/src/aptos_sdk_v2/
+      carryforward: true
+
+comment:
+  layout: "header, diff, flags, components, files"
+  behavior: default
+  require_changes: false
+  show_carryforward_flags: true
+
+# Files under aptos_sdk/v2/ are a mirror of v2/src/aptos_sdk_v2; don't
+# double-count them — the v2-sdk flag covers the canonical copy.
+ignore:
+  - "aptos_sdk/v2/**"
+  - "**/test_*.py"
+  - "tests/**"
+  - "v2/tests/**"
+  - "examples/**"
+  - "features/**"
+  - "benchmarks/**"


### PR DESCRIPTION
## Summary
- Adds `codecov.yml` that partitions coverage between the legacy `v1-sdk` package (`aptos_sdk/`) and the standalone `v2-sdk` package (`v2/src/aptos_sdk_v2/`) via Codecov flags, ignores the `aptos_sdk/v2/` mirror to avoid double-counting, and excludes tests/examples/benchmarks.
- Tags the `lints` workflow upload with the `v1-sdk` flag (the `v2-ci` upload already uses `v2-sdk`) and threads `CODECOV_TOKEN` through both workflows so uploads are authenticated.
- Adds a Codecov badge to the README.

## Test plan
- [ ] CI green on both `lints` and `V2 SDK CI` workflows
- [ ] Codecov reports two distinct flags (`v1-sdk`, `v2-sdk`) on the PR check
- [ ] `aptos_sdk/v2/**` does not appear under the `v1-sdk` flag in the Codecov UI
- [ ] Codecov badge in README renders against `main` after merge