### PR TITLE
Add Innovation-Enabling Source
   Code License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,66 @@
+# Innovation-Enabling Source Code License
+
+Copyright © Aptos Foundation
+Parts of the project are originally copyright © Meta Platforms, Inc.
+
+-----------------------------------------------------------------------------
+
+"Licensed Work" shall mean the work of authorship, whether in source code or
+object code form or otherwise, made available under this license, as
+indicated by a notice that is included in or attached to the work.
+
+Aptos Foundation (the "Licensor") hereby grants you the right to copy,
+modify, create derivative works, redistribute, and make non-production and
+non-commercial use of the Licensed Work solely for your internal purposes.
+Without limiting the generality of the foregoing, you may not use the
+Licensed Work (or any information therein) for the purpose of creating,
+publishing, deploying, launching or offering any blockchain or protocols
+(whether in mainnet, testnet, devnet, beta or alpha versions) outside of
+personal, non-production and non-commercial environments.
+
+Notwithstanding the foregoing, on the date that is 4 years after the date
+that the Licensor has publicly uploaded the specific code of the Licensed
+Work that you are using (the "Change Date"), the license herein shall
+automatically terminate and you shall have the right to then use the
+Licensed Work pursuant to the terms of the Apache 2.0 license.
+
+In addition, notwithstanding the foregoing, you may additionally use the
+software included in the repositories available at this link
+(https://docs.google.com/spreadsheets/d/1YXfK8bpXNbXUhRtH1hZAaZGdDPyM-ppoKuh6hoLC3Cs/edit?gid=0#gid=0)
+for production commercial uses (the "Additional Use Grant Software"), but
+solely to the extent if such uses are (i) for an application built
+exclusively on the Aptos protocol and (ii) not Competing Uses. "Competing
+Use" means any use of the Additional Use Grant Software in any product,
+protocol, application or service that is made available to third parties and
+that (i) (a) substitutes for use of Aptos protocol or (b) is related to the
+development of a layer 1 or layer 2 blockchain, (ii) offers similar
+functionality as the Aptos protocol or (iii) is built on or using a protocol
+other than Aptos protocol.
+
+All copies of the original and modified Licensed Work, and derivative works
+of the Licensed Work, are subject to this License. This License applies
+separately for each version of the Licensed Work and the Change Date may
+vary for each version of the Licensed Work released by Licensor.
+
+You must conspicuously display this License on each original or modified
+copy of the Licensed Work. If you receive the Licensed Work in original or
+modified form from a third party, the terms and conditions set forth in this
+License apply to your use of that work.
+
+Any use of the Licensed Work in violation of this License will automatically
+terminate your rights under this License for the current and all other
+versions of the Licensed Work. You may contact Aptos Foundation if you are
+interested in seeking a commercial license.
+
+This License does not grant you any right in any trademark or logo of
+Licensor or its affiliates (provided that you may use a trademark or logo of
+Licensor as expressly required by this License).
+
+TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
+AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
+EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
+TITLE. TO THE FULLEST EXTENT PERMITTED UNDER APPLICABLE LAW, LICENSOR SHALL
+NOT BE LIABLE TO YOU OR ANY OTHER PERSON FOR ANY LOST PROFITS, LOSS OF
+REVENUE OR BUSINESS, COST OF COVER OR ANY INCIDENTAL, SPECIAL OR
+CONSEQUENTIAL DAMAGES OF ANY KIND AND NATURE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,15 @@ name = "aptos-sdk"
 version = "0.11.0"
 description = "Aptos SDK"
 authors = [{ name = "Aptos Labs", email = "opensource@aptoslabs.com" }]
-license = "Apache-2.0"
+license = {file = "LICENSE"}
 readme = "README.md"
 requires-python = ">=3.12"
 keywords = ["web3", "sdk", "aptos", "blockchain"]
+classifiers = [
+    "License :: Other/Proprietary License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+]
 
 dependencies = [
     "cryptography>=46.0.7,<47",


### PR DESCRIPTION

### Description
Adds the LICENSE file (matching aptos-labs/aptos-core) and updates
pyproject.toml to reference it via {file = "LICENSE"} with the correct
"License :: Other/Proprietary License" classifier instead of the
incorrect Apache-2.0 SPDX identifier.

### Test Plan
<!-- Please provide us with clear details for verifying that your changes work. -->

### Related Links
<!-- Please link to any relevant issues or pull requests! -->
