### PR TITLE
Verify map decoding bug report — not an SDK bug

### DIFF
--- a/aptos_sdk/bcs.py
+++ b/aptos_sdk/bcs.py
@@ -313,6 +313,28 @@ class Test(unittest.TestCase):
 
         self.assertEqual(in_value, out_value)
 
+    def test_struct_args_are_not_maps(self):
+        """Struct entry-function args serialize field values, not field-name maps."""
+        from .account_address import AccountAddress
+
+        collection = "0xd42cd397c41a62eaf03e83ad0324ff6822178a3e40aa596c4b9930561d4753e5"
+        address = AccountAddress.from_str(collection)
+
+        ser_map = Serializer()
+        ser_map.map({"inner": collection}, Serializer.str, Serializer.str)
+        map_bytes = ser_map.output()
+
+        ser_struct = Serializer()
+        address.serialize(ser_struct)
+        struct_bytes = ser_struct.output()
+
+        self.assertNotEqual(map_bytes, struct_bytes)
+        self.assertEqual(struct_bytes.hex(), collection.removeprefix("0x"))
+        self.assertEqual(
+            Deserializer(map_bytes).map(Deserializer.str, Deserializer.str),
+            {"inner": collection},
+        )
+
     def test_sequence(self):
         in_value = ["a", "abc", "def", "ghi"]
 

--- a/v2/tests/unit/test_transactions.py
+++ b/v2/tests/unit/test_transactions.py
@@ -24,7 +24,7 @@ class TestStructArgumentEncoding:
 
     Explorers render struct arguments as JSON objects (e.g. ``{"inner": "0x..."}``),
     but BCS encodes structs as ordered field values. Move ``map<K, V>`` is a different
-    type with its own encoding (length + lexicographically sorted key/value pairs).
+    type with its own encoding (uleb128 length + key/value pairs sorted by encoded key bytes).
     """
 
     COLLECTION = "0xd42cd397c41a62eaf03e83ad0324ff6822178a3e40aa596c4b9930561d4753e5"

--- a/v2/tests/unit/test_transactions.py
+++ b/v2/tests/unit/test_transactions.py
@@ -19,6 +19,47 @@ from aptos_sdk_v2.types.account_address import AccountAddress
 from aptos_sdk_v2.types.type_tag import StructTag, TypeTag
 
 
+class TestStructArgumentEncoding:
+    """Struct entry-function args must not be encoded with Serializer.map.
+
+    Explorers render struct arguments as JSON objects (e.g. ``{"inner": "0x..."}``),
+    but BCS encodes structs as ordered field values. Move ``map<K, V>`` is a different
+    type with its own encoding (length + lexicographically sorted key/value pairs).
+    """
+
+    COLLECTION = "0xd42cd397c41a62eaf03e83ad0324ff6822178a3e40aa596c4b9930561d4753e5"
+
+    def test_map_encoding_round_trips(self):
+        values = {"inner": self.COLLECTION}
+        ser = Serializer()
+        ser.map(values, Serializer.str, Serializer.str)
+        assert Deserializer(ser.output()).map(Deserializer.str, Deserializer.str) == values
+
+    def test_object_inner_field_is_address_not_map(self):
+        collection = AccountAddress.from_str(self.COLLECTION)
+
+        wrong = TransactionArgument(
+            {"inner": self.COLLECTION},
+            lambda ser, val: ser.map(val, Serializer.str, Serializer.str),
+        )
+        correct = TransactionArgument(collection, Serializer.struct)
+
+        assert wrong.encode() != correct.encode()
+        assert correct.encode().hex() == self.COLLECTION.removeprefix("0x")
+
+    def test_vector_field_is_sequence_not_map(self):
+        wrong = TransactionArgument(
+            {"vec": ["1"]},
+            lambda ser, val: ser.map(
+                val, Serializer.str, Serializer.sequence_serializer(Serializer.str)
+            ),
+        )
+        correct = TransactionArgument(["1"], Serializer.sequence_serializer(Serializer.str))
+
+        assert wrong.encode() != correct.encode()
+        assert correct.encode().hex() == "010131"
+
+
 class TestEntryFunctionSignVerify:
     def test_sign_and_verify(self):
         private_key = Ed25519PrivateKey.generate()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Re-verified the [Bug] Map decoding report against the current SDK (v1 `aptos_sdk` and v2 `aptos_sdk_v2`) using mainnet transaction [1829613228](https://explorer.aptoslabs.com/txn/1829613228/userTxnOverview?network=mainnet).

**Conclusion: this is not an SDK bug.** `Serializer.map` / `Deserializer.map` round-trip correctly. The reported failure comes from using map encoding for Move **struct** arguments.

## Root cause

The explorer renders entry-function struct arguments as JSON objects like `{"inner": "0x..."}` and `{"vec": ["1"]}`, which look like Python dicts. Those are **not** Move `map<K, V>` values.

For `unmanaged_launchpad::mint`, the correct BCS encoding is:

| Argument | Explorer JSON | Correct encoding |
|---|---|---|
| Collection object | `{"inner": "0x..."}` | Serialize the address only (`Serializer.struct` on `AccountAddress`) |
| Quantity wrapper | `{"vec": ["1"]}` | Serialize the vector only (`Serializer.sequence_serializer(Serializer.str)`) |

Using `Serializer.map` on a Python dict produces a Move map (length prefix + sorted key/value pairs), which does not match struct field layout and will not decode correctly on-chain.

### Byte comparison (mainnet reference)

```
# Wrong (map encoding of {"inner": address})
0105696e6e65724230786434...

# Correct (struct field: address only)
d42cd397c41a62eaf03e83ad0324ff6822178a3e40aa596c4b9930561d4753e5

# Wrong (map encoding of {"vec": ["1"]})
0103766563010131

# Correct (struct field: vector<String>)
010131
```

## Correct usage

```python
from aptos_sdk.account_address import AccountAddress
from aptos_sdk.bcs import Serializer
from aptos_sdk.transactions import TransactionArgument

collection = AccountAddress.from_str("0xd42cd397c41a62eaf03e83ad0324ff6822178a3e40aa596c4b9930561d4753e5")

args = [
    TransactionArgument(collection, Serializer.struct),
    TransactionArgument(["1"], Serializer.sequence_serializer(Serializer.str)),
]
```

## Changes in this PR

- Added regression tests in `v2/tests/unit/test_transactions.py` (`TestStructArgumentEncoding`)
- Added a matching test in `aptos_sdk/bcs.py` documenting struct-vs-map distinction

## Recommendation

Close the original bug report as **user error / documentation gap**, not a serializer defect. If helpful, we can follow up with a short example for struct-wrapped entry function arguments.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dce81d37-6c99-4969-a8aa-50b03a00c59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dce81d37-6c99-4969-a8aa-50b03a00c59b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

