### PR TITLE
chore: prepare 0.12.1 patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,12 @@ All notable changes to the Aptos Python SDK will be captured in this file. This 
 
 ## Unreleased
 
+## 0.12.1 (2026-08-13)
+
+### Changed
+
 - Make e2e / localnet examples more reliable: `aggregator_value` reads both OptionalAggregator variants (aggregator table and integer, as used on localnet), REST and faucet calls retry transient 429/5xx and faucet sequence-number races, and the integration harness waits for the node and reloads network env vars after starting a localnet.
+- Update dependencies: `aiohttp` 3.14.3, `h2` 4.4.1, and `cryptography` 50.0.0 (both the root SDK and the standalone `v2` package), plus a full lockfile refresh.
 
 ## 0.12.0 (2026-07-02)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aptos-sdk"
-version = "0.12.0"
+version = "0.12.1"
 description = "Aptos SDK"
 authors = [{ name = "Aptos Labs", email = "opensource@aptoslabs.com" }]
 license = {file = "LICENSE"}

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 
 [[package]]
 name = "aptos-sdk"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Prepares the `0.12.1` patch release of `aptos-sdk`, following the release steps in [`CONTRIBUTING.md`](CONTRIBUTING.md).

## Changes

- Bump `version` in `pyproject.toml` from `0.12.0` to `0.12.1` (and the corresponding entry in `uv.lock` via `uv lock`).
- Cut the `Unreleased` changelog content into a dated `## 0.12.1 (2026-08-13)` section.

Everything landed on `main` since the 0.12.0 release prep is backwards compatible (localnet/e2e test reliability plus dependency updates), so a patch bump is the right increment — no public API changed.

## Changelog section

### Changed

- Make e2e / localnet examples more reliable: `aggregator_value` reads both OptionalAggregator variants (aggregator table and integer, as used on localnet), REST and faucet calls retry transient 429/5xx and faucet sequence-number races, and the integration harness waits for the node and reloads network env vars after starting a localnet.
- Update dependencies: `aiohttp` 3.14.3, `h2` 4.4.1, and `cryptography` 50.0.0 (both the root SDK and the standalone `v2` package), plus a full lockfile refresh.

The standalone `v2` package version (`v2/pyproject.toml`, `0.1.0`) is intentionally left alone — it is versioned and published separately and had no source changes in this window.

## Verification

- `uv run python -m unittest discover -s aptos_sdk/ -p '*.py' -t ..` — 169 tests, OK
- `uv run behave` — 3 features / 248 scenarios passed
- `make lint` — mypy clean on 132 files, ruff clean
- `make fmt` — no changes produced
- `cd v2 && uv run ruff check src/ tests/ && uv run ruff format --check src/ tests/` — clean
- `uv build` — builds `aptos_sdk-0.12.1.tar.gz` and `aptos_sdk-0.12.1-py3-none-any.whl`, so the publish workflow's tag/version check will pass for tag `v0.12.1`

## Remaining maintainer step

Publishing is automated but release creation is not: after this merges to `main`, create a GitHub Release from `main` with tag and title `v0.12.1` and the 0.12.1 changelog section as the notes. Publishing the release triggers `Publish aptos-sdk to PyPI`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25414590-a866-4a20-8754-fbd64433267b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25414590-a866-4a20-8754-fbd64433267b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

